### PR TITLE
fix(lib): add a more meaningful error message

### DIFF
--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -84,6 +84,9 @@ class SlideConfig(BaseModel):
     def start_animation_is_before_end(cls, values):
         if values["start_animation"] >= values["end_animation"]:
 
+            if values["start_animation"] == values["end_animation"] == 0:
+                raise ValueError("You have to play at least one animation (e.g., `self.wait()`) before pausing. If you want to start paused, use the approriate command-line option when presenting.")
+
             raise ValueError(
                 "Start animation index must be strictly lower than end animation index"
             )

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -85,7 +85,9 @@ class SlideConfig(BaseModel):
         if values["start_animation"] >= values["end_animation"]:
 
             if values["start_animation"] == values["end_animation"] == 0:
-                raise ValueError("You have to play at least one animation (e.g., `self.wait()`) before pausing. If you want to start paused, use the approriate command-line option when presenting.")
+                raise ValueError(
+                    "You have to play at least one animation (e.g., `self.wait()`) before pausing. If you want to start paused, use the approriate command-line option when presenting."
+                )
 
             raise ValueError(
                 "Start animation index must be strictly lower than end animation index"


### PR DESCRIPTION
This adds an error message to explain why calling `self.pause()` cannot work if no previous animation was played.