### PR TITLE
Issue more templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -14,7 +14,7 @@ body:
 
 
         ⚠
-        Verify first that your issue is not already reported on GitHub[Issues].
+        Verify first that your issue is not already reported on GitHub [Issues].
 
 
         [Issues]:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -64,7 +64,7 @@ body:
       description: |
         Read the [Manim Slides Code of Conduct][CoC] first.
 
-        [CoC]: 
+        [CoC]:
       options:
         - label: I agree to follow the Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -57,4 +57,3 @@ body:
       description: A clear and concise description of how you want to update it.
     validations:
       required: false
-

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -57,14 +57,3 @@ body:
       description: A clear and concise description of how you want to update it.
     validations:
       required: false
-
-  - type: checkboxes
-    attributes:
-      label: Code of Conduct
-      description: |
-        Read the [Manim Slides Code of Conduct][CoC] first.
-
-        [CoC]:
-      options:
-        - label: I agree to follow the Code of Conduct
-          required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -9,12 +9,16 @@ body:
       value: >
         **Thank you for wanting to report a problem with manim-slides docs!**
 
+
         If the problem seems straightforward, feel free to submit a PR instead!
+
 
         ⚠
         Verify first that your issue is not already reported on GitHub[Issues].
 
-        [Issues]: https://github.com/jeertmans/manim-slides/issues
+
+        [Issues]:
+        https://github.com/jeertmans/manim-slides/issues
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -57,3 +57,4 @@ body:
       description: A clear and concise description of how you want to update it.
     validations:
       required: false
+

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,66 @@
+name: Documentation
+description: Ask / Report an issue related to the documentation.
+title: "DOC: <description>"
+labels: ['bug', 'docs']
+
+body:
+  - type: markdown
+    attributes:
+      value: >
+        **Thank you for wanting to report a problem with manim-slides docs!**
+
+        If the problem seems straightforward, feel free to submit a PR instead!
+
+        ⚠
+        Verify first that your issue is not already reported on GitHub[Issues].
+
+        [Issues]: https://github.com/jeertmans/manim-slides/issues
+
+  - type: textarea
+    attributes:
+      label: Describe the Issue
+      description: A clear and concise description of the issue you encountered.
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Affected Page
+      description: Add a link to the coding challenge with the problem.
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Issue Type
+      description: >
+        Please select the option in the drop-down.
+
+        <details>
+          <summary>
+            <em>Issue?</em>
+          </summary>
+        </details>
+      options:
+        - Documentation Enhancement
+        - Documentation Report
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Recommended fix or suggestions
+      description: A clear and concise description of how you want to update it.
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: |
+        Read the [Manim Slides Code of Conduct][CoC] first.
+
+        [CoC]: 
+      options:
+        - label: I agree to follow the Code of Conduct
+          required: true


### PR DESCRIPTION
<!-- This PR `Closes #42 `-->

## Description

-  Template drafted for documentation
-  Consists of attributes for describing the issue, link to affected page, Issue type, Recommendation
- Code of conduct is also added, can keep or remove them subjected to approval

## Check List (Check all the applicable boxes)

- [x] I understand that my contributions needs to pass the checks.
- [x] If I created new functions / methods, I documented them and add type hints.
- [ ] If I modified already existing code, I updated the documentation accordingly.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<img width="1185" alt="Screenshot 2022-10-19 at 8 13 59 PM" src="https://user-images.githubusercontent.com/34807905/196725308-5a92f604-c298-46d3-a0ce-21ef890e3f85.png">

## Note to reviewers

Template for Question/Help/Support is put on hold until further clarification. 

Questions :

1. Should we redirect them to a support page or design a template like the other issues ?
2. If questions based template is to be used, what is the plan to revert back to the user ? 