### PR TITLE
feat(cli): add resize mode option

### DIFF
--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -148,3 +148,6 @@ class PresentationConfig(BaseModel):
                 )
 
         return values
+
+
+DEFAULT_CONFIG = Config()


### PR DESCRIPTION
This adds a new option that allows to control how the video is going to be scaled. By default, we now use a smooth rescaling, but fast mode with no interpolation can be used (previously default).