### PR TITLE
fix(ci): setup minimal python version for flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+min_python_version = 3.7
 extend-ignore =
     # E501: line too long
     E501,


### PR DESCRIPTION
This specifies the minimal python version to be check for with flake8, so that we are not annoyed with irrelevant.