### PR TITLE
Remove redundant black hook & specify minimal supported python version for hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,12 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-        args: ["--profile", "black"]
+        args: ["--python-version", "37", "--profile", "black"]
 -   repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:
       - id: black
+        args: ["--target-version", "py37"]
 -   repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,6 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-    -   id: black
 -   repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:


### PR DESCRIPTION
## Description
1. Remove redundant black hook introduced in 7128c01
2. Specify minimal supported python version for hooks – black & isort.
isort: 
```
--py {all,2,27,3,310,35,36,37,38,39,auto}, --python-version {all,2,27,3,310,35,36,37,38,39,auto}
Tells isort to set the known standard library based on the specified Python version.
Default is to assume any Python 3 version could be the target, and use a union of all stdlib modules across versions.
If auto is specified, the version of the interpreter used to run isort (currently: 311) will be used.
```
black:
```
  -t, --target-version [py33|py34|py35|py36|py37|py38|py39|py310|py311]
                                  Python versions that should be supported by
                                  Black's output. [default: per-file auto-
                                  detection]

```