### PR TITLE
fix(convert): correctly quote paths when using ffmpeg on Windows

### DIFF
--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -206,7 +206,7 @@ class PresentationConfig(BaseModel):  # type: ignore
                 dest_path = merge_basenames(files)
 
                 f = tempfile.NamedTemporaryFile(mode="w", delete=False)
-                f.writelines(f"file {os.path.abspath(path)}\n" for path in files)
+                f.writelines(f"file '{os.path.abspath(path)}'\n" for path in files)
                 f.close()
 
                 command = [


### PR DESCRIPTION
## Description

With the current version of ffmpeg on Windows, the file path in the list file must be enclosed by single quotes.

## Check List (Check all the applicable boxes)

- [x] I understand that my contributions needs to pass the checks.
- [x] If I created new functions / methods, I documented them and add type hints.
- [x] If I modified already existing code, I updated the documentation accordingly.
- [x] The title of my pull request is a short description of the requested changes.