### PR TITLE
feat(lib): remove constraint on last animation and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,7 @@ pip install manim-slides
 
 ### Install From Repository
 
-An alternative way to install Manim Slides is to clone the git repository, and install from there:
-
-```bash
-git clone https://github.com/jeertmans/manim-slides
-pip install -e .
-```
-
-> *Note:* the `-e` flag allows you to edit the files, and observe the changes directly when using Manim Slides
+An alternative way to install Manim Slides is to clone the git repository, and install from there: read the [contributing guide](https://eertmans.be/manim-slides/contributing/workflow.html) to know how.
 
 <!-- end install -->
 
@@ -97,13 +90,7 @@ class BasicExample(Slide):
 
         self.play(dot.animate.move_to(ORIGIN))
         self.pause()  # Waits user to press continue to go to the next slide
-
-        # Each slide MUST end with an animation
-        # -> self.wait is considered an animation with Manim, not ManimGL
-        self.play(dot.animate.move_to(LEFT))
 ```
-
-You **must** end your `Slide` with a `self.play(...)` or a `self.wait(...)`.
 
 First, render the animation files:
 

--- a/example.py
+++ b/example.py
@@ -31,10 +31,6 @@ class BasicExample(Slide):
         self.play(dot.animate.move_to(ORIGIN))
         self.pause()  # Waits user to press continue to go to the next slide
 
-        # Each slide MUST end with an animation
-        # -> self.wait is considered an animation with Manim, not ManimGL
-        self.play(dot.animate.move_to(LEFT))
-
 
 class ConvertExample(Slide):
     """WARNING: this example does not seem to work with ManimGL."""

--- a/manim_slides/slide.py
+++ b/manim_slides/slide.py
@@ -105,6 +105,11 @@ class Slide(Scene):  # type:ignore
 
     def add_last_slide(self) -> None:
         """Adds a 'last' slide to the end of slides."""
+
+        if self.current_animation == self.slides[-1].end_animation:
+            self.slides[-1].type = SlideType.last
+            return
+
         self.slides.append(
             SlideConfig(
                 type=SlideType.last,


### PR DESCRIPTION
This removes the constraint that required a Slide class to end with a animation. This was actually not needed, and could lead to confusion since `self.wait` is not an animation with ManimGL, but well with Manim.

This fix, however, still means that a calls to `self.wait` with ManimGL, after last `self.pause` call, will be ignored.