### PR TITLE
fix(cli): do not terminate slides early

### DIFF
--- a/example.py
+++ b/example.py
@@ -47,7 +47,7 @@ class MultipleAnimationsInLastSlide(Slide):
         self.play(dot.animate.move_to(UP))
         self.play(dot.animate.move_to(LEFT))
         self.play(dot.animate.move_to(DOWN))
-        
+
         self.next_slide()
 
 

--- a/example.py
+++ b/example.py
@@ -32,6 +32,25 @@ class BasicExample(Slide):
         self.next_slide()  # Waits user to press continue to go to the next slide
 
 
+class MultipleAnimationsInLastSlide(Slide):
+    """This is used to check against solution for issue #161."""
+
+    def construct(self):
+        circle = Circle(color=BLUE)
+        dot = Dot()
+
+        self.play(GrowFromCenter(circle))
+        self.play(FadeIn(dot))
+        self.next_slide()
+
+        self.play(dot.animate.move_to(RIGHT))
+        self.play(dot.animate.move_to(UP))
+        self.play(dot.animate.move_to(LEFT))
+        self.play(dot.animate.move_to(DOWN))
+        
+        self.next_slide()
+
+
 class TestFileTooLong(Slide):
     """This is used to check against solution for issue #123."""
 

--- a/manim_slides/present.py
+++ b/manim_slides/present.py
@@ -199,6 +199,8 @@ class Presentation:
     def rewind_current_slide(self) -> None:
         """Rewinds current slide to first frame."""
         logger.debug("Rewinding current slide")
+        self.current_slide.terminated = False
+
         if self.reverse:
             self.current_animation = self.current_slide.end_animation - 1
         else:


### PR DESCRIPTION
When a slide is replayed (either normally or reversed), its state must be reset.

Closes #161