### PR TITLE
chore(docs): update install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The recommended way to install the latest release is to use pip:
 pip install manim-slides
 ```
 
-Optionally, you can also install Manim or ManimGL using extras[^*]:
+Optionally, you can also install Manim or ManimGL using extras[^1]:
 
 ```bash
 pip install manim-slides[manim]   # For Manim
@@ -62,7 +62,7 @@ pip install manim-slides[manim]   # For Manim
 pip install manim-slides[manimgl] # For ManimGL
 ```
 
-[^*]: NOTE: you still need to have Manim or ManimGL platform-specific dependencies installed on your computer.
+[^1]: NOTE: you still need to have Manim or ManimGL platform-specific dependencies installed on your computer.
 
 ### Install From Repository
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ The recommended way to install the latest release is to use pip:
 pip install manim-slides
 ```
 
+Optionally, you can also install Manim or ManimGL using extras[^*]:
+
+```bash
+pip install manim-slides[manim]   # For Manim
+# or
+pip install manim-slides[manimgl] # For ManimGL
+```
+
+[^*]: NOTE: you still need to have Manim or ManimGL platform-specific dependencies installed on your computer.
+
 ### Install From Repository
 
 An alternative way to install Manim Slides is to clone the git repository, and install from there: read the [contributing guide](https://eertmans.be/manim-slides/contributing/workflow.html) to know how.

--- a/docs/source/contributing/workflow.md
+++ b/docs/source/contributing/workflow.md
@@ -45,7 +45,7 @@ Additionnally, Manim Slides comes with group dependencies for development purpos
 
 ```bash
 poetry install --with dev  # For linters and formatters
-# or 
+# or
 poetry install --with docs # To build the documentation locally
 ```
 

--- a/docs/source/contributing/workflow.md
+++ b/docs/source/contributing/workflow.md
@@ -30,6 +30,32 @@ With Poetry, installation becomes straightforward:
 poetry install
 ```
 
+This, however, only installs the minimal set of dependencies to run the package.
+
+If you would like to install Manim or ManimGL, as documented in the [quickstart](../quickstart),
+you can use the `--extras` option:
+
+```bash
+poetry install --extras manim   # For Manim
+# or
+poetry install --extras manimgl # For ManimGL
+```
+
+Additionnally, Manim Slides comes with group dependencies for development purposes:
+
+```bash
+poetry install --with dev  # For linters and formatters
+# or 
+poetry install --with docs # To build the documentation locally
+```
+
+Another group is `test`, but it is only used for
+[GitHub actions](https://github.com/jeertmans/manim-slides/blob/main/.github/workflows/test_examples.yml).
+
+:::{note}
+You can combine any number of groups or extras when installing the package locally.
+:::
+
 ## Running commands
 
 As modules were installed in a new Python environment, you cannot use them directly in the shell.


### PR DESCRIPTION
Hello @bryanwweber 

This small PR tries to address most of the comments you issued in #169.

The main concern I have with documenting the whole Manim installation procedure is that it takes quite a lot of space (because each platform has its own dependencies) and it would be hard for me to keep it up-to-date if changes happen. Therefore, a simple solution is to link to the correct installation guidelines on their respective website.

What do you think?

Closes #169