### PR TITLE
feat(lib): add `wait-time-between-slides` attribute

### DIFF
--- a/docs/source/reference/api.md
+++ b/docs/source/reference/api.md
@@ -6,7 +6,7 @@ Therefore, we only document here the methods we think the end-user will ever use
 
 ```{eval-rst}
 .. autoclass:: manim_slides.Slide
-    :members: start_loop, end_loop, pause, next_slide, wipe
+    :members: wait_time_between_slides, start_loop, end_loop, pause, next_slide, wipe
 
 .. autoclass:: manim_slides.ThreeDSlide
     :members:


### PR DESCRIPTION
Add a new attribute that will allow to automatically call `self.wait(...)` between two slides, to fix graphical issues.
