### PR TITLE
chore(deps): bump RevealJS' default version to 4.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ In an effort to better document changes, this CHANGELOG document is now created.
   been modified accordingly, and old templates will not work anymore.
   This is a **breaking change**.
   [#271](https://github.com/jeertmans/manim-slides/pull/271)
+- Bumped RevealJS' default version to v4.6.1, and added three new themes.
+  [#272](https://github.com/jeertmans/manim-slides/pull/272)
 
 ### Fixed
 

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -253,6 +253,9 @@ class RevealTheme(str, StrEnum):
     soralized = "solarized"
     blood = "blood"
     moon = "moon"
+    black_contrast = "black-contrast"
+    white_contrast = "white-contrast"
+    dracula = "dracula"
 
 
 class RevealJS(Converter):
@@ -336,7 +339,7 @@ class RevealJS(Converter):
     hide_cursor_time: int = 5000
     # Add. options
     background_color: str = "black"  # TODO: use pydantic.color.Color
-    reveal_version: str = "4.4.0"
+    reveal_version: str = "4.6.1"
     reveal_theme: RevealTheme = RevealTheme.black
     title: str = "Manim Slides"
     model_config = ConfigDict(use_enum_values=True, extra="forbid")


### PR DESCRIPTION
Add 3 new themes: dracula, dark-contrast and white-contrast.
