### PR TITLE
feat(cli): add `next-terminates-loop` CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ In an effort to better document changes, this CHANGELOG document is now created.
 - Added `Slide.next_section` for compatibility with `manim`'s
   `Scene.next_section` method.
   [#295](https://github.com/jeertmans/manim-slides/pull/295)
+- Added `--next-terminates-loop` option to `manim-slides present` for turn a
+  looping slide into a normal one, so that it ends nicely. This is useful to
+  have a smooth transition with the next slide.
+  [#299](https://github.com/jeertmans/manim-slides/pull/299)
 - Added `--playback-rate` option to `manim-slides present` for testing purposes.
   [#300](https://github.com/jeertmans/manim-slides/pull/300)
 - Added `auto_next` option to `Slide`'s `next_slide` method to automatically

--- a/manim_slides/present/__init__.py
+++ b/manim_slides/present/__init__.py
@@ -219,6 +219,12 @@ def start_at_callback(
     default=1.0,
     help="Playback rate of the video slides, see PySide6 docs for details.",
 )
+@click.option(
+    "--next-terminates-loop",
+    "next_terminates_loop",
+    is_flag=True,
+    help="If set, pressing next will turn any looping slide into a play slide.",
+)
 @click.help_option("-h", "--help")
 @verbosity_option
 def present(
@@ -236,6 +242,7 @@ def present(
     start_at_slide_number: int,
     screen_number: Optional[int] = None,
     playback_rate: float = 1.0,
+    next_terminates_loop: bool,
 ) -> None:
     """
     Present SCENE(s), one at a time, in order.
@@ -296,6 +303,7 @@ def present(
         slide_index=start_at_slide_number,
         screen=screen,
         playback_rate=playback_rate,
+        next_terminates_loop=next_terminates_loop,
     )
 
     player.show()

--- a/manim_slides/present/__init__.py
+++ b/manim_slides/present/__init__.py
@@ -240,8 +240,8 @@ def present(
     start_at: Tuple[Optional[int], Optional[int], Optional[int]],
     start_at_scene_number: int,
     start_at_slide_number: int,
-    screen_number: Optional[int] = None,
-    playback_rate: float = 1.0,
+    screen_number: Optional[int],
+    playback_rate: float,
     next_terminates_loop: bool,
 ) -> None:
     """

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -54,6 +54,7 @@ class Player(QMainWindow):  # type: ignore[misc]
         slide_index: int = 0,
         screen: Optional[QScreen] = None,
         playback_rate: float = 1.0,
+        next_terminates_loop: bool = False,
     ):
         super().__init__()
 
@@ -125,6 +126,7 @@ class Player(QMainWindow):  # type: ignore[misc]
         # Misc
 
         self.exit_after_last_slide = exit_after_last_slide
+        self.next_terminates_loop = next_terminates_loop
 
         # Setting-up everything
 
@@ -313,6 +315,8 @@ class Player(QMainWindow):  # type: ignore[misc]
     def next(self) -> None:
         if self.media_player.playbackState() == QMediaPlayer.PausedState:
             self.media_player.play()
+        elif self.next_terminates_loop and self.media_player.loops() != 1:
+            self.media_player.setLoops(1)
         else:
             self.load_next_slide()
 

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -316,7 +316,11 @@ class Player(QMainWindow):  # type: ignore[misc]
         if self.media_player.playbackState() == QMediaPlayer.PausedState:
             self.media_player.play()
         elif self.next_terminates_loop and self.media_player.loops() != 1:
+            position = self.media_player.position()
             self.media_player.setLoops(1)
+            self.media_player.stop()
+            self.media_player.setPosition(position)
+            self.media_player.play()
         else:
             self.load_next_slide()
 


### PR DESCRIPTION
This does not work at the moment, because `setLoops(1)` does not seem to end the current loop. Instead, it finishes the current loop, and plays to more loops before `EndOfMedia` is reached.

Link to forum topic: https://forum.qt.io/topic/151450/qmediaplayer-setloops-1-finishes-current-loop-and-does-two-more-is-it-normal/2?_=1698233106574.

Closes #254
