### PR TITLE
fix(present): bug with Qt and Windows + debug messages

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 5.1.3
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-rc(?P<release>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-rc{release}
 	{major}.{minor}.{patch}
 commit = True

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -217,7 +217,9 @@ class Player(QMainWindow):  # type: ignore[misc]
             self.setWindowState(Qt.WindowFullScreen)
         else:
             w, h = self.current_presentation_config.resolution
-            logger.debug(f"Setting window size accordingly to first presentation resolution: {w}-by-{h}.")
+            logger.debug(
+                f"Setting window size accordingly to first presentation resolution: {w}-by-{h}."
+            )
             geometry = self.geometry()
             geometry.setWidth(w)
             geometry.setHeight(h)
@@ -290,7 +292,9 @@ class Player(QMainWindow):  # type: ignore[misc]
             self.media_player.mediaStatusChanged.connect(media_status_changed)
 
         else:
-            logger.debug("Adding a custom signal handler to skip slide if `--auto-next` is used.")
+            logger.debug(
+                "Adding a custom signal handler to skip slide if `--auto-next` is used."
+            )
 
             def media_status_changed(status: QMediaPlayer.MediaStatus) -> None:
                 if (


### PR DESCRIPTION
Apparently, the "recommended* versions of Qt (i.e., Qt 6.5.1 and 6.5.2) produces errors.

I could not exactly re-produce #315, but I also have `failed to get textures for frame; format: 172 textureConverter null` in the output, as https://github.com/jeertmans/manim-slides/issues/315#issuecomment-1965038997 mentioned.

After searching a bit, this feels like the faulty lines are (at least related to) https://github.com/jeertmans/manim-slides/blob/1dbd2fdde58030867f15d7bf0ecede11d59d6903/manim_slides/present/player.py#L245-L247.

I could not yet find a fix for that, but I created this PR for testing purposes... I also added quite a few debug prints, for the future.

When upgrading  Qt to 6.5.3 and above, the error message disappear, but we then have the same visual issue as described in #293.

This is the logs when I comment the lines mentioned:

```
PS C:\Users\hexyl\Documents\GitHub\manim-slides> pdm run manim-slides BasicExample -v DEBUG
[02/27/24 16:59:48] DEBUG    No configuration file found, using default configuration.                                                                                                            __init__.py:287
                    DEBUG    Instantiating Player instance.                                                                                                                                         player.py:189
                    DEBUG    Setting window size accordingly to first presentation resolution: 1920-by-1080.                                                                                        player.py:220
                    DEBUG    Creating main window.                                                                                                                                                  player.py:230
                    DEBUG    Creating (secondary) info window.                                                                                                                                      player.py:248
                    DEBUG    Attaching callbacks                                                                                                                                                    player.py:264
                    DEBUG    Adding a custom signal handler to skip slide if `--auto-next` is used.                                                                                                 player.py:295
                    DEBUG    Loading media from url = PySide6.QtCore.QUrl('file:slides/files/BasicExample/1a71026ac89d836940b1a0fedd2e8302b359a3887ddad3b1ed1992d0ec19c514.mp4').                   player.py:411
                    DEBUG    Playing the media...                                                                                                                                                   player.py:427
[02/27/24 16:59:49] DEBUG    Signal that presentation changed.                                                                                                                                      player.py:488
                    DEBUG    Signal that slide changed.                                                                                                                                             player.py:495
                    DEBUG    Previewing next slide (if any).                                                                                                                                        player.py:503
    failed to get textures for frame; format: 172 textureConverter null
[02/27/24 16:59:55] DEBUG    [USER] Close event.                                                                                                                                                    player.py:581
                    INFO     Closing gracefully...                                                                                                                                                  player.py:517
                    DEBUG    [USER] Close event.                                                                                                                                                    player.py:581
                    INFO     Closing gracefully...                                                                                                                                                  player.py:517
```

If I put the lines back, the message is:

```
PS C:\Users\hexyl\Documents\GitHub\manim-slides> pdm run manim-slides BasicExample -v DEBUG
[02/27/24 17:02:57] DEBUG    No configuration file found, using default configuration.                                                                                                            __init__.py:287
                    DEBUG    Instantiating Player instance.                                                                                                                                         player.py:189
                    DEBUG    Setting window size accordingly to first presentation resolution: 1920-by-1080.                                                                                        player.py:220
                    DEBUG    Creating main window.                                                                                                                                                  player.py:230
                    DEBUG    Creating (secondary) info window.                                                                                                                                      player.py:248
                    DEBUG    Attaching callbacks                                                                                                                                                    player.py:262
                    DEBUG    Adding a custom signal handler to skip slide if `--auto-next` is used.                                                                                                 player.py:293
                    DEBUG    Loading media from url = PySide6.QtCore.QUrl('file:slides/files/BasicExample/1a71026ac89d836940b1a0fedd2e8302b359a3887ddad3b1ed1992d0ec19c514.mp4').                   player.py:409
                    DEBUG    Playing the media...                                                                                                                                                   player.py:425
                    DEBUG    Signal that presentation changed.                                                                                                                                      player.py:486
                    DEBUG    Signal that slide changed.                                                                                                                                             player.py:493
                    DEBUG    Previewing next slide (if any).                                                                                                                                        player.py:501
    failed to get textures for frame; format: 172 textureConverter null
[AVHWFramesContext @ 00000179046511C0] Static surface pool size exceeded.
[h264 @ 0000017904860500] get_buffer() failed
[h264 @ 0000017904860500] thread_get_buffer() failed
[h264 @ 0000017904860500] decode_slice_header error
[h264 @ 0000017904860500] no frame!
[AVHWFramesContext @ 000001791B030F40] Static surface pool size exceeded.
[h264 @ 000001790485E900] get_buffer() failed
[h264 @ 000001790485E900] thread_get_buffer() failed
[h264 @ 000001790485E900] decode_slice_header error
[h264 @ 000001790485E900] no frame!
[AVHWFramesContext @ 00000179046511C0] Static surface pool size exceeded.
[h264 @ 000001790485A500] get_buffer() failed
[h264 @ 000001790485A500] thread_get_buffer() failed
[h264 @ 000001790485A500] decode_slice_header error
[h264 @ 000001790485A500] no frame!
...
Output was truncated
```

Now with `PySide6==6.5.3`:

```
PS C:\Users\hexyl\Documents\GitHub\manim-slides> pdm run manim-slides BasicExample -v DEBUG
[02/27/24 17:04:42] DEBUG    No configuration file found, using default configuration.                                                                                                            __init__.py:287
[02/27/24 17:04:43] WARNING  You are using API = 'pyside6', QT_VERSION = '6.5.3', but we recommend installing 'PySide6==6.5.2', mainly to avoid flashing screens between slides, see issue         __init__.py:23
                             https://github.com/jeertmans/manim-slides/issues/293. You can do so with `pip install 'manim-slides[pyside6]'`.
[02/27/24 17:04:44] DEBUG    Instantiating Player instance.                                                                                                                                         player.py:189
                    DEBUG    Setting window size accordingly to first presentation resolution: 1920-by-1080.                                                                                        player.py:220
                    DEBUG    Creating main window.                                                                                                                                                  player.py:230
                    DEBUG    Creating (secondary) info window.                                                                                                                                      player.py:248
                    DEBUG    Attaching callbacks                                                                                                                                                    player.py:262
                    DEBUG    Adding a custom signal handler to skip slide if `--auto-next` is used.                                                                                                 player.py:293
                    DEBUG    Loading media from url = PySide6.QtCore.QUrl('file:slides/files/BasicExample/1a71026ac89d836940b1a0fedd2e8302b359a3887ddad3b1ed1992d0ec19c514.mp4').                   player.py:409
                    DEBUG    Playing the media...                                                                                                                                                   player.py:425
                    DEBUG    Signal that presentation changed.                                                                                                                                      player.py:486
                    DEBUG    Signal that slide changed.                                                                                                                                             player.py:493
                    DEBUG    Previewing next slide (if any).                                                                                                                                        player.py:501
    failed to get textures for frame; format: 172 textureConverter null
[02/27/24 17:04:48] DEBUG    [USER] Key press event <PySide6.QtGui.QKeyEvent(KeyPress, Key_Q, text="q")>.                                                                                           player.py:583
                    INFO     Closing gracefully...                                                                                                                                                  player.py:515
                    DEBUG    [USER] Close event.                                                                                                                                                    player.py:579
                    INFO     Closing gracefully...                                                                                                                                                  player.py:515
                    DEBUG    [USER] Close event.                                                                                                                                                    player.py:579
                    INFO     Closing gracefully...                                                                                                                                                  player.py:515
```