### PR TITLE
feat(present): add audio output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- start changelog -->
 
 (unreleased)=
-## [Unreleased](https://github.com/jeertmans/manim-slides/compare/v5.1.0...HEAD)
+## [Unreleased](https://github.com/jeertmans/manim-slides/compare/v5.1.3...HEAD)
+
+(unreleased-added)=
+### Added
+
+- Added audio output to `manim-slides present`.
+  [#381](https://github.com/jeertmans/manim-slides/pull/381)
+
+(v5.1.3)=
+## [v5.1.3](https://github.com/jeertmans/manim-slides/compare/v5.1.2...v5.1.3)
+
+(v5.1.3-chore)=
+### Chore
+
+- Fix link in documentation.
+  [#368](https://github.com/jeertmans/manim-slides/pull/368)
+
+- Warn users if not using recommended Qt bindings.
+  [#373](https://github.com/jeertmans/manim-slides/pull/373)
+
+(v5.1.2)=
+## [v5.1.2](https://github.com/jeertmans/manim-slides/compare/v5.1.1...v5.1.2)
+
+(v5.1.2-chore)=
+### Chore
+
+- Fix ReadTheDocs version flyout in iframes.
+  [#367](https://github.com/jeertmans/manim-slides/pull/367)
 
 (v5.1.1)=
 ## [v5.1.1](https://github.com/jeertmans/manim-slides/compare/v5.1.0...v5.1.1)

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from qtpy.QtCore import Qt, QTimer, QUrl, Signal, Slot
 from qtpy.QtGui import QCloseEvent, QIcon, QKeyEvent, QScreen
-from qtpy.QtMultimedia import QMediaPlayer
+from qtpy.QtMultimedia import QAudioOutput, QMediaPlayer
 from qtpy.QtMultimediaWidgets import QVideoWidget
 from qtpy.QtWidgets import (
     QHBoxLayout,
@@ -225,12 +225,14 @@ class Player(QMainWindow):  # type: ignore[misc]
         self.icon = QIcon(":/icon.png")
         self.setWindowIcon(self.icon)
 
+        self.audio_output = QAudioOutput()
         self.video_widget = QVideoWidget()
         self.video_sink = self.video_widget.videoSink()
         self.video_widget.setAspectRatioMode(aspect_ratio_mode)
         self.setCentralWidget(self.video_widget)
 
         self.media_player = QMediaPlayer(self)
+        self.media_player.setAudioOutput(self.audio_output)
         self.media_player.setVideoOutput(self.video_widget)
         self.playback_rate = playback_rate
 


### PR DESCRIPTION
This PR adds the necessary audio output to the presenter mode, so it can play audio contained in video files, see #375.

However, this does not fix the issue that slides do not contain audio by default, but should be solved by Manim, see #375 for updates on that topic.
