### PR TITLE
fix(convert): Whitespace issue in default RevealJS template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix combining assets from multiple scenes to avoid filename collision.
   [#429](https://github.com/jeertmans/manim-slides/pull/429)
+- Fixed whitespace issue in default RevealJS template.
+  [#442](https://github.com/jeertmans/manim-slides/pull/442)
 
 (v5.1.7)=
 ## [v5.1.7](https://github.com/jeertmans/manim-slides/compare/v5.1.6...v5.1.7)

--- a/docs/source/_static/template.html
+++ b/docs/source/_static/template.html
@@ -32,7 +32,7 @@
               data-background-video="{{ file }}"
               {% if loop.index == 1 and outer_loop.index == 1 -%}
                 data-background-video-muted
-              {%- endif -%}
+              {%- endif %}
               {% if slide_config.loop -%}
                 data-background-video-loop
               {%- endif -%}

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -33,7 +33,7 @@
               data-background-video="{{ file }}"
               {% if loop.index == 1 and outer_loop.index == 1 -%}
                 data-background-video-muted
-              {%- endif -%}
+              {%- endif %}
               {% if slide_config.loop -%}
                 data-background-video-loop
               {%- endif -%}


### PR DESCRIPTION
## Description
First of all, thanks for the amazing project!

Recently, I was trying to deploy my animation to web using RevealJS where I wanted the first slide to loop. On the player, everything was working fine, but on the website, the first slide wasn't looping. When I looked at the produced `html` file, I saw this:

```html
...
  <body>
    <div class="reveal">
      <div class="slides"><section
              data-background-size='contain'
              data-background-color="#181926"
              data-background-video="index_assets/{very_long_asset_id}.mp4"
              data-background-video-muteddata-background-video-loop>
              
            </section></div>
    </div>

    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/5.1.0/reveal.min.js"></script>
...
```

I think there's a problem with the spacing of `data-background-video-muted` and `data-background-video-loop` [default RevealJS template](https://github.com/jeertmans/manim-slides/blob/main/manim_slides/templates/revealjs.html).

I tested my current change in my slides, it worked fine. I recommend checking out [Jinja2's whitespace control](https://tedboy.github.io/jinja2/templ6.html).

## Check List (Check all the applicable boxes)

- [x] I understand that my contributions needs to pass the checks.
- [x] If I created new functions / methods, I documented them and add type hints.
- [x] If I modified already existing code, I updated the documentation accordingly.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
