### PR TITLE
chore(lib): Remove old validation check preventing `loop=True` with `auto_next=True`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed whitespace issue in default RevealJS template.
   [#442](https://github.com/jeertmans/manim-slides/pull/442)
 
+(unreleased-chore)=
+### Chore
+
+- Removed an old validation check that prevented setting `loop=True` with
+  `auto_next=True` on `next_slide()`
+  [#445](https://github.com/jeertmans/manim-slides/pull/445)
+
 (v5.1.7)=
 ## [v5.1.7](https://github.com/jeertmans/manim-slides/compare/v5.1.6...v5.1.7)
 

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -262,21 +262,6 @@ class PreSlideConfig(BaseSlideConfig):
 
         return pre_slide_config
 
-    @model_validator(mode="after")
-    @classmethod
-    def loop_and_auto_next_disallowed(
-        cls, pre_slide_config: "PreSlideConfig"
-    ) -> "PreSlideConfig":
-        if pre_slide_config.loop and pre_slide_config.auto_next:
-            raise ValueError(
-                "You cannot have both `loop=True` and `auto_next=True`, "
-                "because a looping slide has no ending. "
-                "This may be supported in the future if "
-                "https://github.com/jeertmans/manim-slides/pull/299 gets merged."
-            )
-
-        return pre_slide_config
-
     @property
     def slides_slice(self) -> slice:
         return slice(self.start_animation, self.end_animation)

--- a/tests/test_slide.py
+++ b/tests/test_slide.py
@@ -22,7 +22,6 @@ from manim import (
     Text,
 )
 from packaging import version
-from pydantic import ValidationError
 
 from manim_slides.config import PresentationConfig
 from manim_slides.defaults import FOLDER_PATH

--- a/tests/test_slide.py
+++ b/tests/test_slide.py
@@ -193,7 +193,7 @@ class TestSlide:
             assert not self._base_slide_config.auto_next
 
     @assert_constructs
-    class TestLoopAndAutoNextFails(Slide):
+    class TestLoopAndAutoNextSucceeds(Slide):
         def construct(self) -> None:
             text = Text("Some text")
 
@@ -202,8 +202,7 @@ class TestSlide:
             self.next_slide(loop=True, auto_next=True)
             self.play(text.animate.scale(2))
 
-            with pytest.raises(ValidationError):
-                self.next_slide()
+            self.next_slide()
 
     @assert_constructs
     class TestPlaybackRate(Slide):


### PR DESCRIPTION
## Description

#299 added support for stopping looping slides smoothly, at which point specifying both `loop=True` and `auto_next=True` on a `next_slide` starts making sense. There is an old validation check in the code referencing #299 that was never removed.

This functionality (on the next press, waiting for the current loop to end and then immediately proceeding to the next slide) seems to work without issues on the QT presenter. The reveal.js presenter doesn't like it as much, but it's also not supported by `--next-terminates-loop`.

## Check List (Check all the applicable boxes)

- [x] I understand that my contributions needs to pass the checks.
- [x] If I created new functions / methods, I documented them and add type hints.
- [x] If I modified already existing code, I updated the documentation accordingly.
- [x] The title of my pull request is a short description of the requested changes.