### PR TITLE
Fix for #293 and similar errors

### DIFF
--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -245,12 +245,11 @@ class Player(QMainWindow):  # type: ignore[misc]
         def frame_changed(frame: QVideoFrame) -> None:
             nonlocal old_frame
 
-            if old_frame and (frame.size() != old_frame.size()):
+            if frame.pixelFormat().value == frame.pixelFormat().Format_Invalid.value:
                 self.video_sink.setVideoFrame(old_frame)
-                frame = old_frame
-
-            self.info.video_sink.setVideoFrame(frame)
-            old_frame = frame
+            else:
+                self.info.video_sink.setVideoFrame(frame)
+                old_frame = frame
 
         self.info = Info(
             full_screen=full_screen,

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -259,9 +259,7 @@ class Player(QMainWindow):  # type: ignore[misc]
         )
         self.info.close_event.connect(self.closeEvent)
         self.info.key_press_event.connect(self.keyPressEvent)
-        self.video_sink.videoFrameChanged.connect(
-            frame_changed
-        )
+        self.video_sink.videoFrameChanged.connect(frame_changed)
         self.hide_info_window = hide_info_window
 
         # Connecting key callbacks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ manim = ["manim>=0.18.0"]
 manimgl = ["manimgl>=1.6.1;python_version<'3.12'"]
 pyqt6 = ["pyqt6>=6.6.1"]
 pyqt6-full = ["manim-slides[full,pyqt6]"]
-pyside6 = ["pyside6>=6.5.1,<6.5.3;python_version<'3.12'", "pyside6>=6.6.1;python_version>='3.12'"]
+pyside6 = ["pyside6>=6.6.1"]
 pyside6-full = ["manim-slides[full,pyside6]"]
 sphinx-directive = ["docutils>=0.20.1", "manim-slides[manim]"]
 tests = [


### PR DESCRIPTION
This pull request fixes the screen going black after the video ends in versions of PySide6 v6.5.3 and newer. This allows for other errors (like #315) that require a newer version of PySide6 to also be fixed.

## Fixes Issue

Closes #315 

## Description

I was attempting to get `manim-slides` to work with the new versions of PySide6, as to stop the `Device loss detected in Present()` error, and found that at the end of the video, a frame of size (-1, -1) would attempt to appear. So, to prevent this, I added a requirement that the frame should only be displayed if it is the same size as the frame before it. Upon adding, the video no longer disappeared once it ended.

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.
