### PR TITLE
feat(cli): allow multiple reverses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   HTML presentations.
   [#440](https://github.com/jeertmans/manim-slides/pull/440)
 
+(unreleased-changed)=
+### Changed
+
+- Allow multiple slide reverses by going backward [@PeculiarProgrammer](https://github.com/PeculiarProgrammer).
+  [#488](https://github.com/jeertmans/manim-slides/pull/488)
+
 (v5.1.9)=
 ## [v5.1.9](https://github.com/jeertmans/manim-slides/compare/v5.1.8...v5.1.9)
 

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -515,6 +515,9 @@ class Player(QMainWindow):  # type: ignore[misc]
 
     @Slot()
     def reverse(self) -> None:
+        if self.playing_reversed_slide and self.current_slide_index >= 1:
+            self.current_slide_index -= 1
+
         self.load_reversed_slide()
         self.preview_next_slide()
 


### PR DESCRIPTION
## Description

Issue #308 refers to the inability to reverse multiple times. I fixed this by decreasing the slide index by one if reverse was invoked twice consecutively with no next-slides in between.

More specifically, the issue mentions the following:

1. Reverse to the end of the previous slide
2. Go directly to the end of the previous slide
3. Go directly to the beginning of the previous slide

This PR fixes the first. The second option seems to be the same as the first just without the animation, so I don't think an implementation of that is needed. The third option seems to just be the back button without the animation, which I also don't think is necessary.

## Fixes Issue

Closes #308 

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.
