### PR TITLE
fix(convert): blank web page when converting multiple slides into HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `av<14`, as their syntax differ, but the former doesn't
   provide binary wheels for Python 3.9.
   [#494](https://github.com/jeertmans/manim-slides/pull/494)
-- Fixed blank web page when converting multiple slides into HTML [#497](https://github.com/jeertmans/manim-slides/pull/497)
+- Fixed blank web page when converting multiple slides into HTML.
+  [#497](https://github.com/jeertmans/manim-slides/pull/497)
 
 (v5.1.9)=
 ## [v5.1.9](https://github.com/jeertmans/manim-slides/compare/v5.1.8...v5.1.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `av<14`, as their syntax differ, but the former doesn't
   provide binary wheels for Python 3.9.
   [#494](https://github.com/jeertmans/manim-slides/pull/494)
+- Fixed blank web page when converting multiple slides into HTML [#497](https://github.com/jeertmans/manim-slides/pull/497)
 
 (v5.1.9)=
 ## [v5.1.9](https://github.com/jeertmans/manim-slides/compare/v5.1.8...v5.1.9)

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -453,6 +453,7 @@ class RevealJS(Converter):
                 get_duration_ms=get_duration_ms,
                 has_notes=has_notes,
                 env=os.environ,
+                prefix=prefix if not self.data_uri else None,
                 **options,
             )
 

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -25,7 +25,7 @@
             {%- if data_uri -%}
               {% set file = file_to_data_uri(slide_config.file) %}
             {%- else -%}
-              {% set file = assets_dir / slide_config.file.name %}
+              {% set file = assets_dir / (prefix(outer_loop.index0) + slide_config.file.name) %}
             {%- endif -%}
         <section
           data-background-size={{ background_size }}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
When manin-slides convert multiple slides into html, it add prefix to animation file in asset directory to prevent filename collision (as https://github.com/jeertmans/manim-slides/issues/428 mentioned) but doesn't add the prefix in HTML's reference to the file.

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Description

I modified the HTML templates and pass prefix function to it.

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers


<!-- Add notes to reviewers if applicable -->

See https://github.com/jeertmans/manim-slides/issues/496 also.
