### PR TITLE
feat(convert/html): inline CSS and JS with convert --one_file --offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (unreleased)=
 ## [Unreleased](https://github.com/jeertmans/manim-slides/compare/v5.2.0...HEAD)
 
+(unreleased-changed)=
+### Added
+
+- Added CSS and JS inline for `manim-slides convert` if `--offline`
+  and `--one-file` (`-cone_file`) are used for HTML output.
+  [@Rapsssito](https://github.com/Rapsssito) [#505](https://github.com/jeertmans/manim-slides/pull/505)
+
+(unreleased-changed)=
+### Changed
+
+- Deprecate `-cdata_uri` in favor of `-cone_file` for `manim-slides convert`.
+  [@Rapsssito](https://github.com/Rapsssito) [#505](https://github.com/jeertmans/manim-slides/pull/505)
+
 (v5.2.0)=
 ## [v5.2.0](https://github.com/jeertmans/manim-slides/compare/v5.1.10...v5.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (unreleased)=
 ## [Unreleased](https://github.com/jeertmans/manim-slides/compare/v5.2.0...HEAD)
 
-(unreleased-changed)=
+(unreleased-added)=
 ### Added
 
 - Added CSS and JS inline for `manim-slides convert` if `--offline`

--- a/docs/source/_static/template.html
+++ b/docs/source/_static/template.html
@@ -21,7 +21,7 @@
         {%- for presentation_config in presentation_configs -%}
           {% set outer_loop = loop %}
           {%- for slide_config in presentation_config.slides -%}
-            {%- if data_uri -%}
+            {%- if one_file -%}
               {% set file = file_to_data_uri(slide_config.file) %}
             {%- else -%}
               {% set file = assets_dir / slide_config.file.name %}
@@ -315,7 +315,7 @@
         hideCursorTime: {{ hide_cursor_time }}
       });
 
-      {% if data_uri %}
+      {% if one_file %}
         // Fix found by @t-fritsch on GitHub
         // see: https://github.com/hakimel/reveal.js/discussions/3362#discussioncomment-6651475.
         function fixBase64VideoBackground(event) {

--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -102,7 +102,7 @@ Questions related to `manim-slides convert [SCENES]... output.html`.
 
 ### I moved my `.html` file and it stopped working
 
-If you did not specify `--one_file` when converting,
+If you did not specify `--one-file` (or `-cone_file=true`) when converting,
 then Manim Slides generated a folder containing all
 the video files, in the same folder as the HTML
 output. As the path to video files is a relative path,

--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -102,7 +102,7 @@ Questions related to `manim-slides convert [SCENES]... output.html`.
 
 ### I moved my `.html` file and it stopped working
 
-If you did not specify `--one-file` when converting,
+If you did not specify `--one_file` when converting,
 then Manim Slides generated a folder containing all
 the video files, in the same folder as the HTML
 output. As the path to video files is a relative path,

--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -102,7 +102,7 @@ Questions related to `manim-slides convert [SCENES]... output.html`.
 
 ### I moved my `.html` file and it stopped working
 
-If you did not specify `-cdata_uri=true` when converting,
+If you did not specify `--one-file` when converting,
 then Manim Slides generated a folder containing all
 the video files, in the same folder as the HTML
 output. As the path to video files is a relative path,

--- a/docs/source/reference/sharing.md
+++ b/docs/source/reference/sharing.md
@@ -138,7 +138,7 @@ and it there to preserve the original aspect ratio (16:9).
 ### Sharing ONE HTML file
 
 If you set the `--one_file` flag, all animations will be data URI encoded,
-making the HTML a self-contained presentation file that can be shared 
+making the HTML a self-contained presentation file that can be shared
 on its own. If you also set the `--offline` flag, the JS and CSS files will
 be included in the HTML file as well.
 

--- a/docs/source/reference/sharing.md
+++ b/docs/source/reference/sharing.md
@@ -137,7 +137,7 @@ and it there to preserve the original aspect ratio (16:9).
 
 ### Sharing ONE HTML file
 
-If you set the `--one_file` flag, all animations will be data URI encoded,
+If you set the `--one-file` flag, all animations will be data URI encoded,
 making the HTML a self-contained presentation file that can be shared
 on its own. If you also set the `--offline` flag, the JS and CSS files will
 be included in the HTML file as well.

--- a/docs/source/reference/sharing.md
+++ b/docs/source/reference/sharing.md
@@ -137,9 +137,10 @@ and it there to preserve the original aspect ratio (16:9).
 
 ### Sharing ONE HTML file
 
-If you set the `data_uri` option to `true` (with `-cdata_uri=true`),
-all animations will be data URI encoded, making the HTML a self-contained
-presentation file that can be shared on its own.
+If you set the `--one_file` flag, all animations will be data URI encoded,
+making the HTML a self-contained presentation file that can be shared 
+on its own. If you also set the `--offline` flag, the JS and CSS files will
+be included in the HTML file as well.
 
 ### Over the internet
 

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -984,16 +984,23 @@ def convert(
         else:
             cls = Converter.from_string(to)
 
-        # Change data_uri to one_file and print a warning
+        # Change data_uri to one_file and print a warning if present
         if "data_uri" in config_options:
-            warnings.simplefilter("default")
             warnings.warn(
-                "The 'data_uri' configuration option is deprecated. "
+                "The 'data_uri' configuration option is deprecated and will be "
+                "removed in the next major version. "
                 "Use 'one_file' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            config_options.setdefaut("one_file", config_options.pop("data_uri"))
+            config_options.setdefaut("one_file", config_options.pop("data_uri"))       
+
+        if (
+            one_file or 
+            and issubclass(cls, (RevealJS, HtmlZip))
+            and "one_file" not in config_options
+        ):
+            config_options["one_file"] = "true"
 
         if (
             offline

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -731,7 +731,7 @@ def show_template_option(function: Callable[..., Any]) -> Callable[..., Any]:
     "To echo the default template, use '--show-template'.",
 )
 @click.option(
-    "--one-file",
+    "--one_file",
     is_flag=True,
     help="Save all assets in a single HTML file.",
 )

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -984,6 +984,13 @@ def convert(
         else:
             cls = Converter.from_string(to)
 
+        if (
+            one_file
+            and issubclass(cls, (RevealJS, HtmlZip))
+            and "one_file" not in config_options
+        ):
+            config_options["one_file"] = "true"
+
         # Change data_uri to one_file and print a warning if present
         if "data_uri" in config_options:
             warnings.warn(
@@ -993,14 +1000,12 @@ def convert(
                 DeprecationWarning,
                 stacklevel=2,
             )
-            config_options.setdefaut("one_file", config_options.pop("data_uri"))
-
-        if (
-            one_file or
-            and issubclass(cls, (RevealJS, HtmlZip))
-            and "one_file" not in config_options
-        ):
-            config_options["one_file"] = "true"
+            config_options["one_file"] = (
+                config_options["one_file"]
+                if "one_file" in config_options
+                else config_options["data_uri"]
+            )
+            config_options.pop("data_uri")
 
         if (
             offline

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -4,8 +4,8 @@ import platform
 import shutil
 import subprocess
 import tempfile
-import webbrowser
 import warnings
+import webbrowser
 from base64 import b64encode
 from collections import deque
 from enum import Enum
@@ -487,12 +487,12 @@ class RevealJS(Converter):
                                 script.string = asset.text
                                 soup.head.append(script)
                             else:
-                                raise ValueError(f"Unable to inline {tag} asset: {link}")
+                                raise ValueError(
+                                    f"Unable to inline {tag} asset: {link}"
+                                )
                         else:
                             full_assets_dir.mkdir(parents=True, exist_ok=True)
-                            with open(
-                                full_assets_dir / asset_name, "wb"
-                            ) as asset_file:
+                            with open(full_assets_dir / asset_name, "wb") as asset_file:
                                 asset_file.write(asset.content)
 
                             item[inner] = str(assets_dir / asset_name)
@@ -780,9 +780,9 @@ def convert(
             config_options["one_file"] = config_options.pop("data_uri")
 
         if (
-            offline and
-            issubclass(cls, (RevealJS, HtmlZip)) and
-            "offline" not in config_options
+            offline
+            and issubclass(cls, (RevealJS, HtmlZip))
+            and "offline" not in config_options
         ):
             config_options["offline"] = "true"
 

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -481,7 +481,9 @@ class RevealJS(Converter):
                                 soup.head.append(script)
                             else:
                                 full_assets_dir.mkdir(parents=True, exist_ok=True)
-                                with open(full_assets_dir / asset_name, "wb") as asset_file:
+                                with open(
+                                    full_assets_dir / asset_name, "wb"
+                                ) as asset_file:
                                     asset_file.write(asset.content)
 
                                 item[inner] = str(assets_dir / asset_name)

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -298,7 +298,7 @@ class RevealJS(Converter):
 
     Please check out https://revealjs.com/config/ for more details.
     """
-    
+
     # Export option:
     one_file: bool = Field(
         False, description="Embed all assets (e.g., animations) inside the HTML."

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -773,9 +773,12 @@ def convert(
 
         # Change data_uri to one_file and print a warning
         if "data_uri" in config_options:
+            warnings.simplefilter("default")
             warnings.warn(
                 "The 'data_uri' configuration option is deprecated. "
-                "Use 'one_file' instead."
+                "Use 'one_file' instead.",
+                DeprecationWarning,
+                stacklevel=2,
             )
             config_options["one_file"] = config_options.pop("data_uri")
 

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -993,10 +993,10 @@ def convert(
                 DeprecationWarning,
                 stacklevel=2,
             )
-            config_options.setdefaut("one_file", config_options.pop("data_uri"))       
+            config_options.setdefaut("one_file", config_options.pop("data_uri"))
 
         if (
-            one_file or 
+            one_file or
             and issubclass(cls, (RevealJS, HtmlZip))
             and "one_file" not in config_options
         ):

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -943,7 +943,7 @@ def show_template_option(function: Callable[..., Any]) -> Callable[..., Any]:
     "To echo the default template, use '--show-template'.",
 )
 @click.option(
-    "--one_file",
+    "--one-file",
     is_flag=True,
     help="Embed all local assets (e.g., video files) in the output file. "
     "The is a convenient alias to '-cone_file=true'.",

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -1003,9 +1003,8 @@ def convert(
             config_options["one_file"] = (
                 config_options["one_file"]
                 if "one_file" in config_options
-                else config_options["data_uri"]
+                else config_options.pop("data_uri")
             )
-            config_options.pop("data_uri")
 
         if (
             offline

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -945,7 +945,8 @@ def show_template_option(function: Callable[..., Any]) -> Callable[..., Any]:
 @click.option(
     "--one_file",
     is_flag=True,
-    help="Save all assets in a single HTML file.",
+    help="Embed all local assets (e.g., video files) in the output file. "
+    "The is a convenient alias to '-cone_file=true'.",
 )
 @click.option(
     "--offline",

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -780,7 +780,7 @@ def convert(
                 DeprecationWarning,
                 stacklevel=2,
             )
-            config_options["one_file"] = config_options.pop("data_uri")
+            config_options.setdefaut("one_file", config_options.pop("data_uri"))
 
         if (
             offline

--- a/manim_slides/ipython/ipython_magic.py
+++ b/manim_slides/ipython/ipython_magic.py
@@ -222,6 +222,18 @@ class ManimSlidesMagic(Magics):  # type: ignore
 
             kwargs = dict(arg.split("=", 1) for arg in manim_slides_args)
 
+            # If data_uri is set, raise a warning
+            if "data_uri" in kwargs:
+                logger.warning(
+                    "'data_uri' configuration option is deprecated and will be removed in a future release. "
+                    "Please use 'one_file' instead."
+                )
+                kwargs["one_file"] = (
+                    kwargs["one_file"]
+                    if "one_file" in kwargs
+                    else kwargs.pop("data_uri")
+                )
+
             if embed:  # Embedding implies one_file
                 kwargs["one_file"] = "true"
 

--- a/manim_slides/ipython/ipython_magic.py
+++ b/manim_slides/ipython/ipython_magic.py
@@ -125,7 +125,7 @@ class ManimSlidesMagic(Magics):  # type: ignore
         in a cell and evaluate it. Then, a typical Jupyter notebook cell for Manim Slides
         could look as follows::
 
-            %%manim_slides -v WARNING --progress_bar None MySlide --manim-slides controls=true one_file
+            %%manim_slides -v WARNING --progress_bar None MySlide --manim-slides controls=true one_file=true
 
             class MySlide(Slide):
                 def construct(self):

--- a/manim_slides/ipython/ipython_magic.py
+++ b/manim_slides/ipython/ipython_magic.py
@@ -222,11 +222,11 @@ class ManimSlidesMagic(Magics):  # type: ignore
 
             kwargs = dict(arg.split("=", 1) for arg in manim_slides_args)
 
-            if embed:  # Embedding implies data-uri
+            if embed:  # Embedding implies one_file
                 kwargs["one_file"] = "true"
 
             # TODO: FIXME
-            # Seems like files are blocked so date-uri is the only working option...
+            # Seems like files are blocked so one_file is the only working option...
             if kwargs.get("one_file", "false").lower().strip() == "false":
                 logger.warning(
                     "one_file option is currently automatically enabled, "

--- a/manim_slides/ipython/ipython_magic.py
+++ b/manim_slides/ipython/ipython_magic.py
@@ -125,7 +125,7 @@ class ManimSlidesMagic(Magics):  # type: ignore
         in a cell and evaluate it. Then, a typical Jupyter notebook cell for Manim Slides
         could look as follows::
 
-            %%manim_slides -v WARNING --progress_bar None MySlide --manim-slides controls=true data_uri=true
+            %%manim_slides -v WARNING --progress_bar None MySlide --manim-slides controls=true one_file
 
             class MySlide(Slide):
                 def construct(self):
@@ -223,16 +223,16 @@ class ManimSlidesMagic(Magics):  # type: ignore
             kwargs = dict(arg.split("=", 1) for arg in manim_slides_args)
 
             if embed:  # Embedding implies data-uri
-                kwargs["data_uri"] = "true"
+                kwargs["one_file"] = "true"
 
             # TODO: FIXME
             # Seems like files are blocked so date-uri is the only working option...
-            if kwargs.get("data_uri", "false").lower().strip() == "false":
+            if kwargs.get("one_file", "false").lower().strip() == "false":
                 logger.warning(
-                    "data_uri option is currently automatically enabled, "
+                    "one_file option is currently automatically enabled, "
                     "because using local video files does not seem to work properly."
                 )
-                kwargs["data_uri"] = "true"
+                kwargs["one_file"] = "true"
 
             presentation_configs = get_scenes_presentation_config(
                 [clsname], Path("./slides")

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -22,7 +22,7 @@
         {% for presentation_config in presentation_configs -%}
           {% set outer_loop = loop %}
           {%- for slide_config in presentation_config.slides -%}
-            {%- if data_uri -%}
+            {%- if one_file -%}
               {% set file = file_to_data_uri(slide_config.file) %}
             {%- else -%}
               {% set file = assets_dir / (prefix(outer_loop.index0) + slide_config.file.name) %}
@@ -317,7 +317,7 @@
         hideCursorTime: {{ hide_cursor_time }}
       });
 
-      {% if data_uri -%}
+      {% if one_file -%}
       // Fix found by @t-fritsch on GitHub
       // see: https://github.com/hakimel/reveal.js/discussions/3362#discussioncomment-6651475.
       function fixBase64VideoBackground(event) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ tests = [
   "pytest-env>=0.8.2",
   "pytest-missing-modules>=0.1.0",
   "pytest-qt>=4.2.0",
-  "pytest-mock>=3.14.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ tests = [
   "pytest-env>=0.8.2",
   "pytest-missing-modules>=0.1.0",
   "pytest-qt>=4.2.0",
+  "pytest-mock>=3.14.0",
 ]
 
 [project.scripts]

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -176,6 +176,58 @@ class TestConverter:
         ]:
             assert (assets_dir / file).exists()
 
+    def test_revealjs_offline_data_encode(
+        self,
+        tmp_path: Path,
+        presentation_config: PresentationConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Mock requests.Session.get to return a fake response (should not be called)
+        class MockResponse:
+            def __init__(self, content: bytes, text: str, status_code: int) -> None:
+                self.content = content
+                self.text = text
+                self.status_code = status_code
+
+        # Apply the monkeypatch
+        monkeypatch.setattr(
+            requests.Session,
+            "get",
+            lambda self, url: MockResponse(
+                b"body { background-color: #9a3241; }",
+                "body { background-color: #9a3241; }",
+                200,
+            ),
+        )
+        out_file = tmp_path / "slides.html"
+        RevealJS(
+            presentation_configs=[presentation_config], offline="false", one_file="true"
+        ).convert_to(out_file)
+        assert out_file.exists()
+        # Check that assets are not stored
+        assert not (tmp_path / "slides_assets").exists()
+
+        with open(out_file, encoding="utf-8") as file:
+            content = file.read()
+
+        soup = BeautifulSoup(content, "html.parser")
+
+        # Check if video is encoded in base64
+        videos = soup.find_all("section")
+        assert all(
+            "data:video/mp4;base64," in video["data-background-video"]
+            for video in videos
+        )
+
+        # Check if CSS is not inlined
+        styles = soup.find_all("style")
+        assert not any("background-color: #9a3241;" in style.string for style in styles)
+        # Check if JS is not inlined
+        scripts = soup.find_all("script")
+        assert not any(
+            "background-color: #9a3241;" in (script.string or "") for script in scripts
+        )
+
     def test_revealjs_offline_inlining(
         self,
         tmp_path: Path,
@@ -193,7 +245,7 @@ class TestConverter:
         monkeypatch.setattr(
             requests.Session,
             "get",
-            lambda: MockResponse(
+            lambda self, url: MockResponse(
                 b"body { background-color: #9a3241; }",
                 "body { background-color: #9a3241; }",
                 200,

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 import requests
 from bs4 import BeautifulSoup
-from pydantic import ValidationError
 
 from manim_slides.config import PresentationConfig
 from manim_slides.convert import (

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -175,7 +175,7 @@ class TestConverter:
         ]:
             assert (assets_dir / file).exists()
 
-    def test_revealjs_offline_data_encode(
+    def test_revealjs_data_encode(
         self,
         tmp_path: Path,
         presentation_config: PresentationConfig,

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -191,15 +191,19 @@ class TestConverter:
 
         # Mock function for 'get'
         def mock_get(*args, **kwargs):
-            return MockResponse(b"body { background-color: #9a3241; }", "body { background-color: #9a3241; }", 200)
+            return MockResponse(
+                b"body { background-color: #9a3241; }",
+                "body { background-color: #9a3241; }",
+                200,
+            )
 
         # Apply the monkeypatch
         monkeypatch.setattr(requests.Session, "get", mock_get)
 
         out_file = tmp_path / "slides.html"
-        RevealJS(presentation_configs=[presentation_config], offline="true", one_file="true").convert_to(
-            out_file
-        )
+        RevealJS(
+            presentation_configs=[presentation_config], offline="true", one_file="true"
+        ).convert_to(out_file)
         assert out_file.exists()
 
         with open(out_file, encoding="utf-8") as file:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -184,21 +184,21 @@ class TestConverter:
     ) -> None:
         # Mock requests.Session.get to return a fake response
         class MockResponse:
-            def __init__(self, content, text, status_code):
+            def __init__(self, content: bytes, text: str, status_code: int) -> None:
                 self.content = content
                 self.text = text
                 self.status_code = status_code
 
-        # Mock function for 'get'
-        def mock_get(*args, **kwargs):
-            return MockResponse(
+        # Apply the monkeypatch
+        monkeypatch.setattr(
+            requests.Session,
+            "get",
+            lambda: MockResponse(
                 b"body { background-color: #9a3241; }",
                 "body { background-color: #9a3241; }",
                 200,
-            )
-
-        # Apply the monkeypatch
-        monkeypatch.setattr(requests.Session, "get", mock_get)
+            ),
+        )
 
         out_file = tmp_path / "slides.html"
         RevealJS(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import pytest
@@ -62,6 +63,34 @@ def test_convert(slides_folder: Path, extension: str) -> None:
         )
 
         assert results.exit_code == 0
+
+
+@pytest.mark.parametrize(("extension",), [("html",)])
+def test_convert_data_uri_deprecated(slides_folder: Path, extension: str) -> None:
+    runner = CliRunner(mix_stderr=False)
+
+    with runner.isolated_filesystem():
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            results = runner.invoke(
+                cli,
+                [
+                    "convert",
+                    "BasicSlide",
+                    f"basic_example.{extension}",
+                    "--folder",
+                    str(slides_folder),
+                    "--to",
+                    extension,
+                    "-cdata_uri=true",
+                ],
+            )
+            assert any(
+                "'data_uri' configuration option is deprecated" in str(item.message)
+                and item.category is DeprecationWarning
+                for item in w
+            )
+            assert results.exit_code == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Currently, the `--offline` parameter for `convert` stores the JS and CSS files in another folder. Inline CSS and JS makes it easy to share presentations by merging everything into a single HTML file. That way, combined with `-cdata_uri=true`, you don't need to share anything more than one HTML file.

EDIT: Changed `-cdata_uri=true` to `--one_file`. Now, the combination of `--offline` and `--one_file` together pushes the CSS and JS inline.

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.
