### PR TITLE
fix(convert): avoid micro-stuttering with --one-file in HTML presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (unreleased-changed)=
 ### Changed
 
-- fix(convert): avoid micro-stuttering with `--one-file` in HTML presentation.
+- Changed template to avoid micro-stuttering with `--one-file` in HTML presentation.
   [@Rapsssito](https://github.com/Rapsssito) [#508](https://github.com/jeertmans/manim-slides/pull/508)
 - Deprecate `-cdata_uri` in favor of `-cone_file` for `manim-slides convert`.
   [@Rapsssito](https://github.com/Rapsssito) [#505](https://github.com/jeertmans/manim-slides/pull/505)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (unreleased-changed)=
 ### Changed
 
-- Changed template to avoid micro-stuttering with `--one-file` in HTML presentation.
-  [@Rapsssito](https://github.com/Rapsssito) [#508](https://github.com/jeertmans/manim-slides/pull/508)
 - Deprecate `-cdata_uri` in favor of `-cone_file` for `manim-slides convert`.
   [@Rapsssito](https://github.com/Rapsssito) [#505](https://github.com/jeertmans/manim-slides/pull/505)
+- Changed template to avoid micro-stuttering with `--one-file` in HTML presentation.
+  [@Rapsssito](https://github.com/Rapsssito) [#508](https://github.com/jeertmans/manim-slides/pull/508)
 
 (v5.2.0)=
 ## [v5.2.0](https://github.com/jeertmans/manim-slides/compare/v5.1.10...v5.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (unreleased-changed)=
 ### Changed
 
+- fix(convert): avoid micro-stuttering with `--one-file` in HTML presentation.
+  [@Rapsssito](https://github.com/Rapsssito) [#508](https://github.com/jeertmans/manim-slides/pull/508)
 - Deprecate `-cdata_uri` in favor of `-cone_file` for `manim-slides convert`.
   [@Rapsssito](https://github.com/Rapsssito) [#505](https://github.com/jeertmans/manim-slides/pull/505)
 

--- a/docs/source/_static/template.html
+++ b/docs/source/_static/template.html
@@ -316,15 +316,15 @@
       });
 
       {% if one_file %}
-        // Fix found by @t-fritsch on GitHub
-        // see: https://github.com/hakimel/reveal.js/discussions/3362#discussioncomment-6651475.
+        // Fix found by @t-fritsch and @Rapsssito on GitHub
+        // see: https://github.com/hakimel/reveal.js/discussions/3362#discussioncomment-11733074.
         function fixBase64VideoBackground(event) {
-          // event.previousSlide, event.currentSlide, event.indexh, event.indexv
-          if (event.currentSlide.getAttribute('data-background-video')) {
-            const background = Reveal.getSlideBackground(event.indexh, event.indexv),
-              video = background.querySelector('video'),
-              sources = video.querySelectorAll('source');
-
+          // Analyze all slides backgrounds
+          for (const slide of Reveal.getBackgroundsElement().querySelectorAll('.slide-background')) {
+            // Get the slide video and its sources for each background
+            const video = slide.querySelector('video');
+            const sources = video.querySelectorAll('source');
+            // Update the source of the video
             sources.forEach((source, i) => {
               const src = source.getAttribute('src');
               if(src.match(/^data:video.*;base64$/)) {
@@ -334,8 +334,8 @@
             });
           }
         }
+        // Setup base64 videos
         Reveal.on( 'ready', fixBase64VideoBackground );
-        Reveal.on( 'slidechanged', fixBase64VideoBackground );
       {% endif %}
     </script>
 

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -321,15 +321,15 @@
       });
 
       {% if one_file -%}
-      // Fix found by @t-fritsch on GitHub
-      // see: https://github.com/hakimel/reveal.js/discussions/3362#discussioncomment-6651475.
+      // Fix found by @t-fritsch and @Rapsssito on GitHub
+      // see: https://github.com/hakimel/reveal.js/discussions/3362#discussioncomment-11733074.
       function fixBase64VideoBackground(event) {
-        // event.previousSlide, event.currentSlide, event.indexh, event.indexv
-        if (event.currentSlide.getAttribute('data-background-video')) {
-          const background = Reveal.getSlideBackground(event.indexh, event.indexv),
-            video = background.querySelector('video'),
-            sources = video.querySelectorAll('source');
-
+        // Analyze all slides backgrounds
+        for (const slide of Reveal.getBackgroundsElement().querySelectorAll('.slide-background')) {
+          // Get the slide video and its sources for each background
+          const video = slide.querySelector('video');
+          const sources = video.querySelectorAll('source');
+          // Update the source of the video
           sources.forEach((source, i) => {
             const src = source.getAttribute('src');
             if(src.match(/^data:video.*;base64$/)) {
@@ -339,8 +339,8 @@
           });
         }
       }
+      // Setup base64 videos
       Reveal.on( 'ready', fixBase64VideoBackground );
-      Reveal.on( 'slidechanged', fixBase64VideoBackground );
       {%- endif %}
     </script>
 


### PR DESCRIPTION
## Description

As described in https://github.com/hakimel/reveal.js/discussions/3362#discussioncomment-11733074, currently, the base64 representation of the slide is loaded "on the fly" by RevealJS, which in results in a few frames of a blank screen. This solution is only executed once and updates all videos "src" attribute at the beginning of the presentation.

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.
