### PR TITLE
fix(convert): fix missing slides in HTML presentation after #508

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (unreleased)=
 ## [Unreleased](https://github.com/jeertmans/manim-slides/compare/v5.3.0...HEAD)
 
+- Changed template to avoid missing slides in HTML presentation.
+  [@Rapsssito](https://github.com/Rapsssito) [#515](https://github.com/jeertmans/manim-slides/pull/515)
+
 (v5.3.0)=
 ## [v5.3.0](https://github.com/jeertmans/manim-slides/compare/v5.2.0...v5.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (unreleased)=
 ## [Unreleased](https://github.com/jeertmans/manim-slides/compare/v5.3.0...HEAD)
 
-- Changed template to avoid missing slides in HTML presentation.
+(unreleased-fixed)=
+### Fixed
+
+- Fixed HTML template to avoid missing slides when exporting with `--one-file`.
   [@Rapsssito](https://github.com/Rapsssito) [#515](https://github.com/jeertmans/manim-slides/pull/515)
 
 (v5.3.0)=

--- a/docs/source/_static/template.html
+++ b/docs/source/_static/template.html
@@ -316,26 +316,47 @@
       });
 
       {% if one_file %}
-        // Fix found by @t-fritsch and @Rapsssito on GitHub
-        // see: https://github.com/hakimel/reveal.js/discussions/3362#discussioncomment-11733074.
-        function fixBase64VideoBackground(event) {
-          // Analyze all slides backgrounds
-          for (const slide of Reveal.getBackgroundsElement().querySelectorAll('.slide-background')) {
-            // Get the slide video and its sources for each background
-            const video = slide.querySelector('video');
-            const sources = video.querySelectorAll('source');
-            // Update the source of the video
-            sources.forEach((source, i) => {
-              const src = source.getAttribute('src');
-              if(src.match(/^data:video.*;base64$/)) {
-                const nextSrc = sources[i+1]?.getAttribute('src');
-                video.setAttribute('src', `${src},${nextSrc}`);
+      // Fix found by @t-fritsch and @Rapsssito on GitHub
+      // see: https://github.com/hakimel/reveal.js/discussions/3362#discussioncomment-11733074.
+      function setVideoBase64(video) {
+        const sources = video.querySelectorAll('source');
+        // Update the source of the video
+        sources.forEach((source, i) => {
+          const src = source.getAttribute('src');
+          if(src.match(/^data:video.*;base64$/)) {
+            const nextSrc = sources[i+1]?.getAttribute('src');
+            video.setAttribute('src', `${src},${nextSrc}`);
+          }
+        });
+      }
+
+      function fixBase64VideoBackground(event) {
+        // Analyze all slides backgrounds
+        for (const slide of Reveal.getBackgroundsElement().querySelectorAll('.slide-background')) {
+          // Get the slide video and its sources for each background
+          const video = slide.querySelector('video');
+          if (video) {
+            setVideoBase64(video);
+          } else {
+            // Listen to the creation of the video element
+            const observer = new MutationObserver((mutationsList) => {
+              for (const mutation of mutationsList) {
+                if (mutation.type === 'childList') {
+                  for (const addedNode of mutation.addedNodes) {
+                    if (addedNode.tagName === 'VIDEO') {
+                      setVideoBase64(addedNode);
+                      observer.disconnect(); // Stop observing once the video is handled
+                    }
+                  }
+                }
               }
             });
+            observer.observe(slide, { childList: true, subtree: true });
           }
         }
-        // Setup base64 videos
-        Reveal.on( 'ready', fixBase64VideoBackground );
+      }
+      // Setup base64 videos
+      Reveal.on( 'ready', fixBase64VideoBackground );
       {% endif %}
     </script>
 

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -323,20 +323,41 @@
       {% if one_file -%}
       // Fix found by @t-fritsch and @Rapsssito on GitHub
       // see: https://github.com/hakimel/reveal.js/discussions/3362#discussioncomment-11733074.
+      function setVideoBase64(video) {
+        const sources = video.querySelectorAll('source');
+        // Update the source of the video
+        sources.forEach((source, i) => {
+          const src = source.getAttribute('src');
+          if(src.match(/^data:video.*;base64$/)) {
+            const nextSrc = sources[i+1]?.getAttribute('src');
+            video.setAttribute('src', `${src},${nextSrc}`);
+          }
+        });
+      }
+
       function fixBase64VideoBackground(event) {
         // Analyze all slides backgrounds
         for (const slide of Reveal.getBackgroundsElement().querySelectorAll('.slide-background')) {
           // Get the slide video and its sources for each background
           const video = slide.querySelector('video');
-          const sources = video.querySelectorAll('source');
-          // Update the source of the video
-          sources.forEach((source, i) => {
-            const src = source.getAttribute('src');
-            if(src.match(/^data:video.*;base64$/)) {
-              const nextSrc = sources[i+1]?.getAttribute('src');
-              video.setAttribute('src', `${src},${nextSrc}`);
-            }
-          });
+          if (video) {
+            setVideoBase64(video);
+          } else {
+            // Listen to the creation of the video element
+            const observer = new MutationObserver((mutationsList) => {
+              for (const mutation of mutationsList) {
+                if (mutation.type === 'childList') {
+                  for (const addedNode of mutation.addedNodes) {
+                    if (addedNode.tagName === 'VIDEO') {
+                      setVideoBase64(addedNode);
+                      observer.disconnect(); // Stop observing once the video is handled
+                    }
+                  }
+                }
+              }
+            });
+            observer.observe(slide, { childList: true, subtree: true });
+          }
         }
       }
       // Setup base64 videos


### PR DESCRIPTION
## Description

Fixes a problem introduced by #508 where lazy loaded slides by RevealJS are never loaded.

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.