### PR TITLE
chore(html): bump RevealJS version to 5.2

### DIFF
--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -531,7 +531,7 @@ class RevealJS(Converter):
         "black",
         description="Background color used in slides, not relevant if videos fill the whole area.",
     )
-    reveal_version: str = Field("5.1.0", description="RevealJS version.")
+    reveal_version: str = Field("5.2.0", description="RevealJS version.")
     reveal_theme: RevealTheme = Field(
         RevealTheme.black, description="RevealJS version."
     )


### PR DESCRIPTION
Bump version as it includes a nice fix for speaker view: background videos are now played.

See: https://github.com/hakimel/reveal.js/pull/1037#issuecomment-1825352783.
