### PR TITLE
feat(html): always include RevealJS' notes plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (unreleased)=
 ## [Unreleased](https://github.com/jeertmans/manim-slides/compare/v5.5.0...HEAD)
 
+(unreleased-changed)=
+### Changed
+
+- HTML template now always includes the *notes* plugin so that the speaker
+  view is always available. Previously, it was only included if the slides
+  had notes.
+  [#538](https://github.com/jeertmans/manim-slides/pull/538)
+
 (v5.5.0)=
 ## [v5.5.0](https://github.com/jeertmans/manim-slides/compare/v5.4.2...v5.5.0)
 

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -50,11 +50,11 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/reveal.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/plugin/notes/notes.min.js"></script>
 
     <!-- To include plugins, see: https://revealjs.com/plugins/ -->
     {% if has_notes %}
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/plugin/markdown/markdown.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/plugin/notes/notes.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/plugin/markdown/markdown.min.js"></script>
     {% endif %}
 
     <!-- <script src="index.js"></script> -->


### PR DESCRIPTION
This allows to open the speaker view no matter if we had notes included.
