### PR TITLE
feat(html): pause HTML slides with `SPACE` key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   view is always available. Previously, it was only included if the slides
   had notes.
   [#538](https://github.com/jeertmans/manim-slides/pull/538)
-
+- Pressing <kbd>SPACE</kbd> key now pauses the slides, instead of skipping it.
+  Previously, it was not possible to pause HTML slides, which can be very annoying
+  when trying to explain something.
+  [#539](https://github.com/jeertmans/manim-slides/pull/539)
+  
 (v5.5.0)=
 ## [v5.5.0](https://github.com/jeertmans/manim-slides/compare/v5.4.2...v5.5.0)
 

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -262,6 +262,23 @@
         // Time before the cursor is hidden (in ms)
         hideCursorTime: {{ hide_cursor_time }}
       });
+      // Override SPACE to play / pause the video
+      Reveal.addKeyBinding(
+        { 
+          keyCode: 32,
+          key: 'SPACE',
+          description: 'Play / pause video'
+        },
+        () => {
+          var currentVideos = Reveal.getCurrentSlide().slideBackgroundContentElement.getElementsByTagName("video");
+          if (currentVideos.length > 0) {
+            if (currentVideos[0].paused == true) currentVideos[0].play();
+            else currentVideos[0].pause();
+          } else {
+            Reveal.next();
+          }
+        }
+      );
       {% if one_file %}
       // Fix found by @t-fritsch and @Rapsssito on GitHub
       // see: https://github.com/hakimel/reveal.js/discussions/3362#discussioncomment-11733074.

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -264,7 +264,7 @@
       });
       // Override SPACE to play / pause the video
       Reveal.addKeyBinding(
-        { 
+        {
           keyCode: 32,
           key: 'SPACE',
           description: 'Play / pause video'


### PR DESCRIPTION
Pressing <kbd>SPACE</kbd> key now pauses the slides, instead of skipping it.
