### PR TITLE
fix(utils): handle PyAV>=14 template streams with fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new example to the example gallery.
   [@jdgsmallwood](https://github.com/jdgsmallwood) [#589](https://github.com/jeertmans/manim-slides/pull/589)
 
+### Fixed
+
+- Fixed compatibility issue with `av>=14` (and thus `manim>=0.19.2`).
+  [@SockingPanda](https://github.com/SockingPanda) [#584](https://github.com/jeertmans/manim-slides/pull/584)
+
 (v5.5.3)=
 ## [v5.5.3](https://github.com/jeertmans/manim-slides/compare/v5.5.2...v5.5.3)
 

--- a/manim_slides/utils.py
+++ b/manim_slides/utils.py
@@ -12,6 +12,8 @@ from tqdm import tqdm
 
 from .logger import logger
 
+AV_VERSION_14 = int(av.__version__.split(".", maxsplit=1)[0]) >= 14
+
 
 def concatenate_video_files(files: list[Path], dest: Path) -> None:
     """Concatenate multiple video files into one."""
@@ -44,14 +46,26 @@ def concatenate_video_files(files: list[Path], dest: Path) -> None:
         av.open(str(dest), mode="w") as output_container,
     ):
         input_video_stream = input_container.streams.video[0]
-        output_video_stream = output_container.add_stream(
-            template=input_video_stream,
+        output_video_stream = (
+            output_container.add_stream_from_template(
+                input_video_stream,
+            )
+            if AV_VERSION_14
+            else output_container.add_stream(
+                template=input_video_stream,
+            )
         )
 
         if len(input_container.streams.audio) > 0:
             input_audio_stream = input_container.streams.audio[0]
-            output_audio_stream = output_container.add_stream(
-                template=input_audio_stream,
+            output_audio_stream = (
+                output_container.add_stream_from_template(
+                    input_audio_stream,
+                )
+                if AV_VERSION_14
+                else output_container.add_stream(
+                    template=input_audio_stream,
+                )
             )
 
         for packet in input_container.demux():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  "av>=9.0.0,<14",
+  "av>=9.0.0",
   "beautifulsoup4>=4.12.3",
   "click>=8.1.3",
   "click-default-group>=1.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -2439,7 +2439,7 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "av", specifier = ">=9.0.0,<14" },
+    { name = "av", specifier = ">=9.0.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
     { name = "click", specifier = ">=8.1.3" },
     { name = "click-default-group", specifier = ">=1.2.2" },


### PR DESCRIPTION
## Fixes Issue
Closes #582

## Description
- Switch template stream creation to `add_stream_from_template()` to match PyAV>=14 API changes.
- Add a robust fallback that rebuilds streams with codec_name + key attribute copies when template creation fails.
- Add a unit test covering the fallback path and attribute copying.

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.

> Note: This change does not alter user-facing behavior or usage, only fixes PyAV>=14 compatibility and adds tests, so no user docs or changelog updates were made.

## Screenshots

N/A

## Note to reviewers
- Test command: `python -m pytest tests/test_utils.py -q -o addopts=""`
- Pytest warning about `env` comes from existing global config, not introduced here.