### PR TITLE
Add horizontal flag to next_slide API

### DIFF
--- a/manim_slides/slide/manim.py
+++ b/manim_slides/slide/manim.py
@@ -138,7 +138,6 @@ class Slide(BaseSlide, Scene):  # type: ignore[misc]
         base_slide_config: BaseSlideConfig,
         **kwargs: Any,
     ) -> None:
-
         Scene.next_section(
             self,
             *args,

--- a/manim_slides/slide/manim.py
+++ b/manim_slides/slide/manim.py
@@ -134,9 +134,11 @@ class Slide(BaseSlide, Scene):  # type: ignore[misc]
     def next_slide(
         self,
         *args: Any,
+        horizontal: bool = False,
         base_slide_config: BaseSlideConfig,
         **kwargs: Any,
     ) -> None:
+
         Scene.next_section(
             self,
             *args,


### PR DESCRIPTION
This change extends the `next_slide` method with an optional
`horizontal: bool = False` parameter.

The flag is intended to mark slide boundaries that should start
a new horizontal slide when exporting to HTML (Reveal.js), while
preserving the current default behavior.

No functional changes are introduced yet; this commit only
adds the API surface needed for future HTML export logic.
