### PR TITLE
feat(lib): support static images for slides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added vertical slide implementation to html exports of presentations. [@DaughterOfSpring](https://github.com/daughterOfSpring) [#602](https://github.com/jeertmans/manim-slides/pull/602)
+- Added support for static image in slides with `src` option.
+  [@Low-Zi-Hong](https://github.com/Low-Zi-Hong)[#607](https://github.com/jeertmans/manim-slides/pull/607)
 
 ### Fixed
 

--- a/docs/source/_static/template.html
+++ b/docs/source/_static/template.html
@@ -19,22 +19,38 @@
     <div class="reveal">
       <div class="slides">
         {% for presentation_config in presentation_configs -%}
+        {% set ns = namespace(open_stack=false) %}
           {%- set outer_loop = loop %}
           {% for slide_config in presentation_config.slides %}
             {% if one_file %}
               {% set file = file_to_data_uri(slide_config.file) %}
             {% else %}
-              {% set file = assets_dir / (prefix(outer_loop.index0) + slide_config.file.name) %}
+              {% set file = assets_dir ~ '/' ~ (prefix(outer_loop.index0) + slide_config.file.name) %}
             {% endif %}
+            {% if slide_config.direction == "vertical" %}
+              {% if not ns.open_stack %}
+              <section>
+              {% set ns.open_stack = true %}
+            {% endif %}
+            {% else %}
+              {% if ns.open_stack %}
+              </section>
+              {% set ns.open_stack = false %}
+            {% endif %}
+          {% endif %}
         <section
           data-background-size={{ background_size }}
           data-background-color="{{ presentation_config.background_color }}"
+          {% if slide_config.type.value == "image" %}
+          data-background-image="{{ file }}"
+          {% else %}
           data-background-video="{{ file }}"
           {% if loop.index == 1 and outer_loop.index == 1 %}
           data-background-video-muted
           {% endif %}
           {% if slide_config.loop %}
           data-background-video-loop
+          {% endif %}
           {% endif %}
           {% if slide_config.auto_next %}
           data-autoslide="{{ get_duration_ms(slide_config.file) }}"
@@ -45,6 +61,9 @@
           {% endif %}
         </section>
           {% endfor %}
+        {% if ns.open_stack %}
+         </section>
+        {% endif %}
         {% endfor %}
       </div>
     </div>
@@ -323,13 +342,6 @@
       Reveal.on( 'ready', fixBase64VideoBackground );
       {% endif %}
     </script>
-    {% if env['READTHEDOCS'] %}
-      <style>
-        readthedocs-flyout, readthedocs-notification {
-          display: none;
-        }
-      </style>
-    {% endif %}
 
     <!-- Add a clock to each section dynamically using JavaScript -->
     <script>

--- a/docs/source/reference/examples.md
+++ b/docs/source/reference/examples.md
@@ -170,3 +170,18 @@ A more advanced example is `ConvertExample`, which is used as demo slide and tut
    :linenos:
    :pyobject: ConvertExample
 ```
+
+## Various Media Types
+
+Manim Slides supports including external media files of various media types, such as images (including GIFs) and videos.
+
+```{eval-rst}
+.. manim-slides:: ../../../example.py:SlideTypesExample
+    :hide_source:
+    :quality: high
+
+.. literalinclude:: ../../../example.py
+   :language: python
+   :linenos:
+   :pyobject: SlideTypesExample
+```

--- a/example.py
+++ b/example.py
@@ -320,11 +320,11 @@ class SlideTypesExample(Slide):
         self.play(FadeIn(title))
 
         self.next_slide(
-            src=(Path(__file__).parent / "static" / "logo.png").absolute(),
+            src=Path(__file__).parent / "static" / "logo.png",
             notes="Static image example",
         )
 
         self.next_slide(
-            src=(Path(__file__).parent / "static" / "example.gif").absolute(),
+            src=Path(__file__).parent / "static" / "example.gif",
             notes="GIF image example",
         )

--- a/example.py
+++ b/example.py
@@ -1,6 +1,8 @@
 # flake8: noqa: F403, F405
 # type: ignore
 
+from pathlib import Path
+
 from manim_slides import Slide, ThreeDSlide
 from manim_slides.slide import MANIM, MANIMGL
 
@@ -309,3 +311,20 @@ else:
             self.play(dot.animate.move_to(ORIGIN))
 
     # [manimgl-3d]
+
+
+class SlideTypesExample(Slide):
+    def construct(self):
+        title = Text("Basic slide types")
+
+        self.play(FadeIn(title))
+
+        self.next_slide(
+            src=Path(__file__).parent / "static" / "logo.png",
+            notes="Static image example",
+        )
+
+        self.next_slide(
+            src=Path(__file__).parent / "static" / "example.gif",
+            notes="GIF image example",
+        )

--- a/example.py
+++ b/example.py
@@ -320,11 +320,11 @@ class SlideTypesExample(Slide):
         self.play(FadeIn(title))
 
         self.next_slide(
-            src=Path(__file__).parent / "static" / "logo.png",
+            src=(Path(__file__).parent / "static" / "logo.png").absolute(),
             notes="Static image example",
         )
 
         self.next_slide(
-            src=Path(__file__).parent / "static" / "example.gif",
+            src=(Path(__file__).parent / "static" / "example.gif").absolute(),
             notes="GIF image example",
         )

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -175,7 +175,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
 
     @model_validator(mode="after")
     def validate_static_image(self) -> "BaseSlideConfig":
-        """check if both 'src' and 'static_image' exist at same time or not."""
+        """Check if both 'src' and 'static_image' exist at same time or not."""
         if self.src is not None and self.static_image is not None:
             raise ValueError("Cannot set both 'src' and 'static_image'")
         return self

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -170,7 +170,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
     notes: str = ""
     dedent_notes: bool = True
     skip_animations: bool = False
-    src: Optional[str| Path] = None
+    src: Optional[str | Path] = None
     type: SlideType = SlideType.Video
     direction: Literal["horizontal", "vertical"] = "horizontal"
 

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -1,10 +1,11 @@
 import json
 import shutil
+from enum import Enum
 from functools import wraps
 from inspect import Parameter, signature
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Callable, Literal, Optional, Union
 
 import rtoml
 from pydantic import (
@@ -24,6 +25,11 @@ from .logger import logger
 
 Receiver = Callable[..., Any]
 
+class SlideType(Enum):
+    """Enumeration of slide types."""
+
+    Video = "video"
+    Image = "image"
 
 class Signal(BaseModel):  # type: ignore[misc]
     __receivers: list[Receiver] = PrivateAttr(default_factory=list)
@@ -161,8 +167,24 @@ class BaseSlideConfig(BaseModel):  # type: ignore
     notes: str = ""
     dedent_notes: bool = True
     skip_animations: bool = False
-    src: Optional[FilePath] = None
+    src: Optional[str] = None
+    static_image: Optional[str] = None
     direction: Literal["horizontal", "vertical"] = "horizontal"
+
+    @model_validator(mode="after")
+    def validate_static_image(self) -> "BaseSlideConfig":
+        """check if both 'src' and 'static_image' exist at same time or not"""
+        if self.src is not None and self.static_image is not None:
+            raise ValueError("Cannot set both 'src' and 'static_image'")
+        return self
+    
+    @property
+    def slide_type(self) -> SlideType:
+        """Determine the slide type based on configuration."""
+        if self.static_image is not None:
+            return SlideType.Image
+        return SlideType.Video
+
 
     @classmethod
     def wrapper(cls, arg_name: str) -> Callable[..., Any]:
@@ -210,7 +232,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
     def apply_dedent_notes(
         self,
     ) -> "BaseSlideConfig":
-        if self.dedent_notes:
+        if self.dedent_notes and self.notes is not None:
             self.notes = dedent(self.notes)
 
         return self
@@ -260,7 +282,7 @@ class PreSlideConfig(BaseSlideConfig):
             raise ValueError(
                 "A slide cannot have 'src=...' and more than zero animations at the same time."
             )
-        elif self.src is None and self.start_animation == self.end_animation:
+        elif self.src is None and self.static_image is None and self.start_animation == self.end_animation:
             raise ValueError(
                 "You have to play at least one animation (e.g., 'self.wait()') "
                 "before pausing. If you want to start paused, use the appropriate "

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -6,7 +6,7 @@ from functools import wraps
 from inspect import Parameter, signature
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Any, Callable, Literal, Optional
 
 import rtoml
 from pydantic import (
@@ -170,7 +170,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
     notes: str = ""
     dedent_notes: bool = True
     skip_animations: bool = False
-    src: Optional[Union[str, Path]] = None
+    src: Optional[FilePath] = None
     type: SlideType = SlideType.Video
     direction: Literal["horizontal", "vertical"] = "horizontal"
 

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -181,7 +181,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
         if self.src is not None:
             guessed_typed = mimetypes.guess_type(self.src)[0]
             if guessed_typed is None:
-                Warnings.warn(
+                warnings.warn(
                     f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.",
                     stacklevel=2,
                 )
@@ -191,7 +191,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
             elif guessed_typed.startswith("video"):
                 self.type = SlideType.Video
             else:
-                Warnings.warn(
+                warnings.warn(
                     f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.",
                     stacklevel=2,
                 )

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -173,7 +173,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
 
     @model_validator(mode="after")
     def validate_static_image(self) -> "BaseSlideConfig":
-        """check if both 'src' and 'static_image' exist at same time or not"""
+        """check if both 'src' and 'static_image' exist at same time or not."""
         if self.src is not None and self.static_image is not None:
             raise ValueError("Cannot set both 'src' and 'static_image'")
         return self

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -1,6 +1,7 @@
 import json
 import mimetypes
 import shutil
+import warnings
 from enum import Enum
 from functools import wraps
 from inspect import Parameter, signature

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+import mimetypes
 from enum import Enum
 from functools import wraps
 from inspect import Parameter, signature
@@ -170,22 +171,27 @@ class BaseSlideConfig(BaseModel):  # type: ignore
     dedent_notes: bool = True
     skip_animations: bool = False
     src: Optional[str] = None
-    static_image: Optional[str] = None
+    type: SlideType = SlideType.Video
     direction: Literal["horizontal", "vertical"] = "horizontal"
 
     @model_validator(mode="after")
-    def validate_static_image(self) -> "BaseSlideConfig":
-        """check if both 'src' and 'static_image' exist at same time or not."""
-        if self.src is not None and self.static_image is not None:
-            raise ValueError("Cannot set both 'src' and 'static_image'")
+    def determine_slide_type(self) -> "BaseSlideConfig":
+        """determine the type of src."""
+        if self.src is not None:
+            guessed_typed = mimetypes.guess_type(self.src)[0]
+            if guessed_typed is None:
+                Warning.warn(f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.", stacklevel = 2)
+                self.type = SlideType.Video
+            elif guessed_typed.startswith("image"):
+                self.type = SlideType.Image
+            elif guessed_typed.startswith("video"):
+                self.type = SlideType.Video
+            else:
+                Warning.warn(f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.", stacklevel = 2)
+                self.type = SlideType.Video
+        else:
+            self.type = SlideType.Video
         return self
-
-    @property
-    def slide_type(self) -> SlideType:
-        """Determine the slide type based on configuration."""
-        if self.static_image is not None:
-            return SlideType.Image
-        return SlideType.Video
 
     @classmethod
     def wrapper(cls, arg_name: str) -> Callable[..., Any]:
@@ -285,7 +291,6 @@ class PreSlideConfig(BaseSlideConfig):
             )
         elif (
             self.src is None
-            and self.static_image is None
             and self.start_animation == self.end_animation
         ):
             raise ValueError(

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -1,6 +1,6 @@
 import json
-import shutil
 import mimetypes
+import shutil
 from enum import Enum
 from functools import wraps
 from inspect import Parameter, signature
@@ -176,18 +176,24 @@ class BaseSlideConfig(BaseModel):  # type: ignore
 
     @model_validator(mode="after")
     def determine_slide_type(self) -> "BaseSlideConfig":
-        """determine the type of src."""
+        """Determine the type of src."""
         if self.src is not None:
             guessed_typed = mimetypes.guess_type(self.src)[0]
             if guessed_typed is None:
-                Warning.warn(f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.", stacklevel = 2)
+                Warning.warn(
+                    f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.",
+                    stacklevel=2,
+                )
                 self.type = SlideType.Video
             elif guessed_typed.startswith("image"):
                 self.type = SlideType.Image
             elif guessed_typed.startswith("video"):
                 self.type = SlideType.Video
             else:
-                Warning.warn(f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.", stacklevel = 2)
+                Warning.warn(
+                    f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.",
+                    stacklevel=2,
+                )
                 self.type = SlideType.Video
         else:
             self.type = SlideType.Video
@@ -289,10 +295,7 @@ class PreSlideConfig(BaseSlideConfig):
             raise ValueError(
                 "A slide cannot have 'src=...' and more than zero animations at the same time."
             )
-        elif (
-            self.src is None
-            and self.start_animation == self.end_animation
-        ):
+        elif self.src is None and self.start_animation == self.end_animation:
             raise ValueError(
                 "You have to play at least one animation (e.g., 'self.wait()') "
                 "before pausing. If you want to start paused, use the appropriate "

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -6,7 +6,7 @@ from functools import wraps
 from inspect import Parameter, signature
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Callable, Literal, Optional, Union
 
 import rtoml
 from pydantic import (
@@ -170,7 +170,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
     notes: str = ""
     dedent_notes: bool = True
     skip_animations: bool = False
-    src: Optional[str| Path] = None
+    src: Optional[Union[str| Path]] = None
     type: SlideType = SlideType.Video
     direction: Literal["horizontal", "vertical"] = "horizontal"
 
@@ -180,7 +180,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
         if self.src is not None:
             guessed_typed = mimetypes.guess_type(self.src)[0]
             if guessed_typed is None:
-                Warning.warn(
+                Warnings.warn(
                     f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.",
                     stacklevel=2,
                 )
@@ -190,7 +190,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
             elif guessed_typed.startswith("video"):
                 self.type = SlideType.Video
             else:
-                Warning.warn(
+                Warnings.warn(
                     f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.",
                     stacklevel=2,
                 )

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -182,6 +182,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
             if guessed_typed is None:
                 warnings.warn(
                     f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.",
+                    DeprecationWarning,
                     stacklevel=2,
                 )
                 self.type = SlideType.Video
@@ -192,6 +193,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
             else:
                 warnings.warn(
                     f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.",
+                    DeprecationWarning,
                     stacklevel=2,
                 )
                 self.type = SlideType.Video

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -1,7 +1,6 @@
 import json
 import mimetypes
 import shutil
-import warnings
 from enum import Enum
 from functools import wraps
 from inspect import Parameter, signature

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -182,7 +182,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
             guessed_typed = mimetypes.guess_type(self.src)[0]
             if guessed_typed is None:
                 warnings.warn(
-                    f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.",
+                    f"The file type of 'src' ({str(self.src)!r}) could not be guessed. Defaulting to video type.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -193,13 +193,11 @@ class BaseSlideConfig(BaseModel):  # type: ignore
                 self.type = SlideType.Video
             else:
                 warnings.warn(
-                    f"The 'src' is guessed to be {guessed_typed}, which is currently not supported. Defaulting to video type.",
+                    f"The file type of 'src' ({str(self.src)!r}) could not be guessed. Defaulting to video type.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
                 self.type = SlideType.Video
-        else:
-            self.type = SlideType.Video
         return self
 
     @classmethod
@@ -248,7 +246,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
     def apply_dedent_notes(
         self,
     ) -> "BaseSlideConfig":
-        if self.dedent_notes and self.notes is not None:
+        if self.dedent_notes:
             self.notes = dedent(self.notes)
 
         return self

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -170,7 +170,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
     notes: str = ""
     dedent_notes: bool = True
     skip_animations: bool = False
-    src: Optional[Union[str| Path]] = None
+    src: Optional[Union[str | Path]] = None
     type: SlideType = SlideType.Video
     direction: Literal["horizontal", "vertical"] = "horizontal"
 

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -1,6 +1,7 @@
 import json
 import mimetypes
 import shutil
+import warnings
 from enum import Enum
 from functools import wraps
 from inspect import Parameter, signature
@@ -170,7 +171,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
     notes: str = ""
     dedent_notes: bool = True
     skip_animations: bool = False
-    src: Optional[Union[str| Path]] = None
+    src: Optional[Union[str, Path]] = None
     type: SlideType = SlideType.Video
     direction: Literal["horizontal", "vertical"] = "horizontal"
 

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -170,7 +170,7 @@ class BaseSlideConfig(BaseModel):  # type: ignore
     notes: str = ""
     dedent_notes: bool = True
     skip_animations: bool = False
-    src: Optional[str] = None
+    src: Optional[str| Path] = None
     type: SlideType = SlideType.Video
     direction: Literal["horizontal", "vertical"] = "horizontal"
 

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -1,7 +1,6 @@
 import json
 import mimetypes
 import shutil
-import warnings
 from enum import Enum
 from functools import wraps
 from inspect import Parameter, signature
@@ -181,10 +180,8 @@ class BaseSlideConfig(BaseModel):  # type: ignore
         if self.src is not None:
             guessed_typed = mimetypes.guess_type(self.src)[0]
             if guessed_typed is None:
-                warnings.warn(
+                logger.warning(
                     f"The file type of 'src' ({str(self.src)!r}) could not be guessed. Defaulting to video type.",
-                    DeprecationWarning,
-                    stacklevel=2,
                 )
                 self.type = SlideType.Video
             elif guessed_typed.startswith("image"):
@@ -192,10 +189,8 @@ class BaseSlideConfig(BaseModel):  # type: ignore
             elif guessed_typed.startswith("video"):
                 self.type = SlideType.Video
             else:
-                warnings.warn(
-                    f"The file type of 'src' ({str(self.src)!r}) could not be guessed. Defaulting to video type.",
-                    DeprecationWarning,
-                    stacklevel=2,
+                logger.warning(
+                    f"The file type of 'src' ({str(self.src)!r}) is guessed as {guessed_typed!r}, which is not recognized or currently supported. Defaulting to video type.",
                 )
                 self.type = SlideType.Video
         return self

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -5,7 +5,7 @@ from functools import wraps
 from inspect import Parameter, signature
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Any, Callable, Literal, Optional
 
 import rtoml
 from pydantic import (
@@ -25,11 +25,13 @@ from .logger import logger
 
 Receiver = Callable[..., Any]
 
+
 class SlideType(Enum):
     """Enumeration of slide types."""
 
     Video = "video"
     Image = "image"
+
 
 class Signal(BaseModel):  # type: ignore[misc]
     __receivers: list[Receiver] = PrivateAttr(default_factory=list)
@@ -173,18 +175,17 @@ class BaseSlideConfig(BaseModel):  # type: ignore
 
     @model_validator(mode="after")
     def validate_static_image(self) -> "BaseSlideConfig":
-        """check if both 'src' and 'static_image' exist at same time or not"""
+        """Check if both 'src' and 'static_image' exist at same time or not"""
         if self.src is not None and self.static_image is not None:
             raise ValueError("Cannot set both 'src' and 'static_image'")
         return self
-    
+
     @property
     def slide_type(self) -> SlideType:
         """Determine the slide type based on configuration."""
         if self.static_image is not None:
             return SlideType.Image
         return SlideType.Video
-
 
     @classmethod
     def wrapper(cls, arg_name: str) -> Callable[..., Any]:
@@ -282,7 +283,11 @@ class PreSlideConfig(BaseSlideConfig):
             raise ValueError(
                 "A slide cannot have 'src=...' and more than zero animations at the same time."
             )
-        elif self.src is None and self.static_image is None and self.start_animation == self.end_animation:
+        elif (
+            self.src is None
+            and self.static_image is None
+            and self.start_animation == self.end_animation
+        ):
             raise ValueError(
                 "You have to play at least one animation (e.g., 'self.wait()') "
                 "before pausing. If you want to start paused, use the appropriate "

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -793,6 +793,8 @@ class PowerPoint(Converter):
                 ):
                     file = slide_config.file
 
+                    slide = prs.slides.add_slide(layout)
+
                     if is_image_file(file):
                         # Handle static image
                         slide.shapes.add_picture(

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -89,12 +89,6 @@ def get_duration_ms(file: Path) -> float:
         return float(1000 * video.duration * video.time_base)
 
 
-def is_image_file(file_path: Path) -> bool:
-    """Check if the file is an image based on its extension."""
-    image_extensions = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"}
-    return file_path.suffix.lower() in image_extensions
-
-
 def read_image_from_video_file(file: Path, frame_index: "FrameIndex") -> Image:
     """Read a image from a video file at a given index."""
     with av.open(str(file)) as container:
@@ -567,7 +561,7 @@ class RevealJS(Converter):
         assets_dir = Path(
             self.assets_dir.format(dirname=dirname, basename=basename, ext=ext)
         )
-        full_assets_dir = Path(dirname) / assets_dir
+        full_assets_dir = dirname / assets_dir
 
         if not self.one_file or self.offline:
             logger.debug(f"Assets will be saved to: {full_assets_dir}")
@@ -796,7 +790,7 @@ class PowerPoint(Converter):
 
                     slide = prs.slides.add_slide(layout)
 
-                    if is_image_file(file):
+                    if slide_config.type == SlideType.Image:
                         # Handle static image
                         slide.shapes.add_picture(
                             str(file),

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -88,6 +88,10 @@ def get_duration_ms(file: Path) -> float:
 
         return float(1000 * video.duration * video.time_base)
 
+def is_image_file(file_path: Path) -> bool:
+    """Check if the file is an image based on its extension."""
+    image_extensions = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"}
+    return file_path.suffix.lower() in image_extensions
 
 def read_image_from_video_file(file: Path, frame_index: "FrameIndex") -> Image:
     """Read a image from a video file at a given index."""
@@ -787,34 +791,49 @@ class PowerPoint(Converter):
                 ):
                     file = slide_config.file
 
-                    mime_type = mimetypes.guess_type(file)[0]
-
-                    if self.poster_frame_image is None:
-                        poster_frame_image = str(directory / f"{frame_number}.png")
-                        image = read_image_from_video_file(
-                            file, frame_index=FrameIndex.first
+                    if is_image_file(file):
+                        #Handle static image
+                        slide.shapes.add_picture(
+                            str(file),
+                            self.left,
+                            self.top,
+                            self.width * 9625,
+                            self.height * 9525,
                         )
-                        image.save(poster_frame_image)
-
-                        frame_number += 1
                     else:
-                        poster_frame_image = str(self.poster_frame_image)
+                        #handle video
+                        mime_type = mimetypes.guess_type(file)[0]
 
-                    slide = prs.slides.add_slide(layout)
-                    movie = slide.shapes.add_movie(
-                        str(file),
-                        self.left,
-                        self.top,
-                        self.width * 9525,
-                        self.height * 9525,
-                        poster_frame_image=poster_frame_image,
-                        mime_type=mime_type,
-                    )
+                        if self.poster_frame_image is None:
+                            poster_frame_image = str(directory / f"{frame_number}.png")
+                            image = read_image_from_video_file(
+                                file, frame_index=FrameIndex.first
+                            )
+                            image.save(poster_frame_image)
+
+                            frame_number += 1
+                        else:
+                            poster_frame_image = str(self.poster_frame_image)
+
+                        slide = prs.slides.add_slide(layout)
+                        movie = slide.shapes.add_movie(
+                            str(file),
+                            self.left,
+                            self.top,
+                            self.width * 9525,
+                            self.height * 9525,
+                            poster_frame_image=poster_frame_image,
+                            mime_type=mime_type,
+                        )
+
+                        if self.auto_play_media:
+                            auto_play_media(movie, loop=slide_config.loop)
+                    
+                    
                     if slide_config.notes != "":
                         slide.notes_slide.notes_text_frame.text = slide_config.notes
 
-                    if self.auto_play_media:
-                        auto_play_media(movie, loop=slide_config.loop)
+
 
             dest.parent.mkdir(parents=True, exist_ok=True)
             prs.save(dest)

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -612,7 +612,6 @@ class RevealJS(Converter):
             content = revealjs_template.render(
                 file_to_data_uri=file_to_data_uri,
                 get_duration_ms=get_duration_ms,
-                SlideType=SlideType,
                 has_notes=has_notes,
                 env=os.environ,
                 prefix=prefix if not self.one_file else None,

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -39,7 +39,7 @@ from tqdm import tqdm
 
 from . import templates
 from .commons import folder_path_option, verbosity_option
-from .config import PresentationConfig
+from .config import PresentationConfig,SlideType
 from .logger import logger
 from .present import get_scenes_presentation_config
 
@@ -607,7 +607,7 @@ class RevealJS(Converter):
             options = self.model_dump()
 
             if assets_dir is not None:
-                options["assets_dir"] = assets_dir
+                options["assets_dir"] = assets_dir.as_posix()
 
             has_notes = any(
                 slide_config.notes != ""
@@ -618,6 +618,7 @@ class RevealJS(Converter):
             content = revealjs_template.render(
                 file_to_data_uri=file_to_data_uri,
                 get_duration_ms=get_duration_ms,
+                SlideType=SlideType,
                 has_notes=has_notes,
                 env=os.environ,
                 prefix=prefix if not self.one_file else None,
@@ -819,7 +820,6 @@ class PowerPoint(Converter):
                         else:
                             poster_frame_image = str(self.poster_frame_image)
 
-                        slide = prs.slides.add_slide(layout)
                         movie = slide.shapes.add_movie(
                             str(file),
                             self.left,

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -607,7 +607,7 @@ class RevealJS(Converter):
             options = self.model_dump()
 
             if assets_dir is not None:
-                options["assets_dir"] = assets_dir.as_posix()
+                options["assets_dir"] = assets_dir
 
             has_notes = any(
                 slide_config.notes != ""
@@ -618,7 +618,6 @@ class RevealJS(Converter):
             content = revealjs_template.render(
                 file_to_data_uri=file_to_data_uri,
                 get_duration_ms=get_duration_ms,
-                assets_dir=Path(assets_dir),
                 SlideType=SlideType,
                 has_notes=has_notes,
                 env=os.environ,

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -39,7 +39,7 @@ from tqdm import tqdm
 
 from . import templates
 from .commons import folder_path_option, verbosity_option
-from .config import PresentationConfig,SlideType
+from .config import PresentationConfig, SlideType
 from .logger import logger
 from .present import get_scenes_presentation_config
 

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -88,10 +88,12 @@ def get_duration_ms(file: Path) -> float:
 
         return float(1000 * video.duration * video.time_base)
 
+
 def is_image_file(file_path: Path) -> bool:
     """Check if the file is an image based on its extension."""
     image_extensions = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"}
     return file_path.suffix.lower() in image_extensions
+
 
 def read_image_from_video_file(file: Path, frame_index: "FrameIndex") -> Image:
     """Read a image from a video file at a given index."""
@@ -792,7 +794,7 @@ class PowerPoint(Converter):
                     file = slide_config.file
 
                     if is_image_file(file):
-                        #Handle static image
+                        # Handle static image
                         slide.shapes.add_picture(
                             str(file),
                             self.left,
@@ -801,7 +803,7 @@ class PowerPoint(Converter):
                             self.height * 9525,
                         )
                     else:
-                        #handle video
+                        # handle video
                         mime_type = mimetypes.guess_type(file)[0]
 
                         if self.poster_frame_image is None:
@@ -828,12 +830,9 @@ class PowerPoint(Converter):
 
                         if self.auto_play_media:
                             auto_play_media(movie, loop=slide_config.loop)
-                    
-                    
+
                     if slide_config.notes != "":
                         slide.notes_slide.notes_text_frame.text = slide_config.notes
-
-
 
             dest.parent.mkdir(parents=True, exist_ok=True)
             prs.save(dest)

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -567,7 +567,7 @@ class RevealJS(Converter):
         assets_dir = Path(
             self.assets_dir.format(dirname=dirname, basename=basename, ext=ext)
         )
-        full_assets_dir = dirname / assets_dir
+        full_assets_dir = Path(dirname) / assets_dir
 
         if not self.one_file or self.offline:
             logger.debug(f"Assets will be saved to: {full_assets_dir}")

--- a/manim_slides/docs/manim_slides_directive.py
+++ b/manim_slides/docs/manim_slides_directive.py
@@ -382,7 +382,7 @@ class ManimSlidesDirective(Directive):
             source_file = file.absolute()
             user_code = source_file.read_text().splitlines()
         else:
-            source_file = None
+            source_file = source_file_name.absolute()
             user_code = self.content
 
         if user_code[0].startswith(">>> "):  # check whether block comes from doctest
@@ -398,9 +398,7 @@ class ManimSlidesDirective(Directive):
         try:
             with tempconfig(example_config):
                 print(f"Rendering {clsname}...")  # noqa: T201
-                global_ns = {}
-                if source_file is not None:
-                    global_ns["__file__"] = str(source_file)
+                global_ns = {"__file__": str(source_file)}
                 run_time = timeit(lambda: exec("\n".join(code), global_ns), number=1)
                 video_dir = config.get_dir("video_dir")
         except Exception as e:

--- a/manim_slides/docs/manim_slides_directive.py
+++ b/manim_slides/docs/manim_slides_directive.py
@@ -379,8 +379,10 @@ class ManimSlidesDirective(Directive):
         }
 
         if file := arguments[0][0]:
-            user_code = file.absolute().read_text().splitlines()
+            source_file = file.absolute()
+            user_code = source_file.read_text().splitlines()
         else:
+            source_file = None
             user_code = self.content
 
         if user_code[0].startswith(">>> "):  # check whether block comes from doctest
@@ -396,7 +398,10 @@ class ManimSlidesDirective(Directive):
         try:
             with tempconfig(example_config):
                 print(f"Rendering {clsname}...")  # noqa: T201
-                run_time = timeit(lambda: exec("\n".join(code), globals()), number=1)
+                global_ns = {}
+                if source_file is not None:
+                    global_ns["__file__"] = str(source_file)
+                run_time = timeit(lambda: exec("\n".join(code), global_ns), number=1)
                 video_dir = config.get_dir("video_dir")
         except Exception as e:
             raise RuntimeError(f"Error while rendering example {clsname}") from e

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 from qtpy.QtCore import Qt, QTimer, QUrl, Signal, Slot
-from qtpy.QtGui import QCloseEvent, QIcon, QKeyEvent, QScreen, QPixmap
+from qtpy.QtGui import QCloseEvent, QIcon, QKeyEvent, QPixmap, QScreen
 from qtpy.QtMultimedia import QAudioOutput, QMediaPlayer, QVideoFrame
 from qtpy.QtMultimediaWidgets import QVideoWidget
 from qtpy.QtWidgets import (
@@ -14,7 +14,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ..config import Config, PresentationConfig, SlideConfig ,SlideType
+from ..config import Config, PresentationConfig, SlideConfig, SlideType
 from ..logger import logger
 from ..resources import *  # noqa: F403
 
@@ -44,7 +44,7 @@ class Info(QWidget):  # type: ignore[misc]
         current_container = QWidget()
         current_container.setFixedSize(720, 480)
         current_layout = QVBoxLayout(current_container)
-        current_layout.setContentsMargins(0,0,0,0)
+        current_layout.setContentsMargins(0, 0, 0, 0)
 
         left_layout = QVBoxLayout()
         left_layout.addWidget(
@@ -64,7 +64,6 @@ class Info(QWidget):  # type: ignore[misc]
         current_layout.addWidget(self.main_image_label)
 
         left_layout.addWidget(current_container)
-        
 
         # Current slide information
 
@@ -119,7 +118,7 @@ class Info(QWidget):  # type: ignore[misc]
         preview_container = QWidget()
         preview_container.setFixedSize(360, 240)
         perview_layout = QVBoxLayout(preview_container)
-        perview_layout.setContentsMargins(0,0,0,0)
+        perview_layout.setContentsMargins(0, 0, 0, 0)
 
         right_layout = QVBoxLayout()
         right_layout.addWidget(
@@ -253,11 +252,11 @@ class Player(QMainWindow):  # type: ignore[misc]
         self.video_widget = QVideoWidget()
         self.video_sink = self.video_widget.videoSink()
         self.video_widget.setAspectRatioMode(aspect_ratio_mode)
-        #self.setCentralWidget(self.video_widget)
+        # self.setCentralWidget(self.video_widget)
 
         container = QWidget()
         container_layout = QVBoxLayout(container)
-        container_layout.setContentsMargins(0,0,0,0)
+        container_layout.setContentsMargins(0, 0, 0, 0)
 
         container_layout.addWidget(self.video_widget)
 
@@ -439,7 +438,8 @@ class Player(QMainWindow):  # type: ignore[misc]
 
             if self.playing_reversed_slide:
                 self.media_player.setPlaybackRate(
-                    self.current_slide_config.reversed_playback_rate * self.playback_rate
+                    self.current_slide_config.reversed_playback_rate
+                    * self.playback_rate
                 )
             else:
                 self.media_player.setPlaybackRate(
@@ -460,7 +460,6 @@ class Player(QMainWindow):  # type: ignore[misc]
             self.video_widget.hide()
             self.info.main_image_label.show()
             self.info.main_video_widget.hide()
-
 
     def load_current_slide(self) -> None:
         slide_config = self.current_slide_config
@@ -541,7 +540,6 @@ class Player(QMainWindow):  # type: ignore[misc]
                 self.info.next_image_label.show()
                 self.info.next_media_player.stop()
                 self.info.next_image_label.setPixmap(QPixmap(url.toLocalFile()))
-
 
     def show(self, screens: list[QScreen]) -> None:
         """Screens is necessary to prevent the info window from being shown on the same screen as the main window (especially in full screen mode)."""

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 from qtpy.QtCore import Qt, QTimer, QUrl, Signal, Slot
-from qtpy.QtGui import QCloseEvent, QIcon, QKeyEvent, QScreen
+from qtpy.QtGui import QCloseEvent, QIcon, QKeyEvent, QScreen, QPixmap
 from qtpy.QtMultimedia import QAudioOutput, QMediaPlayer, QVideoFrame
 from qtpy.QtMultimediaWidgets import QVideoWidget
 from qtpy.QtWidgets import (
@@ -14,7 +14,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ..config import Config, PresentationConfig, SlideConfig
+from ..config import Config, PresentationConfig, SlideConfig ,SlideType
 from ..logger import logger
 from ..resources import *  # noqa: F403
 
@@ -41,16 +41,30 @@ class Info(QWidget):  # type: ignore[misc]
 
         # Current slide view
 
+        current_container = QWidget()
+        current_container.setFixedSize(720, 480)
+        current_layout = QVBoxLayout(current_container)
+        current_layout.setContentsMargins(0,0,0,0)
+
         left_layout = QVBoxLayout()
         left_layout.addWidget(
             QLabel("Current slide"),
             alignment=Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignHCenter,
         )
-        main_video_widget = QVideoWidget()
-        main_video_widget.setAspectRatioMode(aspect_ratio_mode)
-        main_video_widget.setFixedSize(720, 480)
-        self.video_sink = main_video_widget.videoSink()
-        left_layout.addWidget(main_video_widget)
+        self.main_video_widget = QVideoWidget()
+        self.main_video_widget.setAspectRatioMode(aspect_ratio_mode)
+        self.video_sink = self.main_video_widget.videoSink()
+
+        current_layout.addWidget(self.main_video_widget)
+
+        self.main_image_label = QLabel()
+        self.main_image_label.setAlignment(Qt.AlignCenter)
+        self.main_image_label.setScaledContents(True)
+        self.main_image_label.hide()
+        current_layout.addWidget(self.main_image_label)
+
+        left_layout.addWidget(current_container)
+        
 
         # Current slide information
 
@@ -102,20 +116,31 @@ class Info(QWidget):  # type: ignore[misc]
         layout.addSpacing(20)
 
         # Next slide preview
+        preview_container = QWidget()
+        preview_container.setFixedSize(360, 240)
+        perview_layout = QVBoxLayout(preview_container)
+        perview_layout.setContentsMargins(0,0,0,0)
 
         right_layout = QVBoxLayout()
         right_layout.addWidget(
             QLabel("Next slide"),
             alignment=Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignHCenter,
         )
-        next_video_widget = QVideoWidget()
-        next_video_widget.setAspectRatioMode(aspect_ratio_mode)
-        next_video_widget.setFixedSize(360, 240)
+        self.next_video_widget = QVideoWidget()
+        self.next_video_widget.setAspectRatioMode(aspect_ratio_mode)
         self.next_media_player = QMediaPlayer()
-        self.next_media_player.setVideoOutput(next_video_widget)
+        self.next_media_player.setVideoOutput(self.next_video_widget)
         self.next_media_player.setLoops(-1)
 
-        right_layout.addWidget(next_video_widget)
+        perview_layout.addWidget(self.next_video_widget)
+
+        self.next_image_label = QLabel()
+        self.next_image_label.setAlignment(Qt.AlignCenter)
+        self.next_image_label.setScaledContents(True)
+        self.next_image_label.hide()
+        perview_layout.addWidget(self.next_image_label)
+
+        right_layout.addWidget(preview_container)
 
         # Notes
 
@@ -228,7 +253,20 @@ class Player(QMainWindow):  # type: ignore[misc]
         self.video_widget = QVideoWidget()
         self.video_sink = self.video_widget.videoSink()
         self.video_widget.setAspectRatioMode(aspect_ratio_mode)
-        self.setCentralWidget(self.video_widget)
+        #self.setCentralWidget(self.video_widget)
+
+        container = QWidget()
+        container_layout = QVBoxLayout(container)
+        container_layout.setContentsMargins(0,0,0,0)
+
+        container_layout.addWidget(self.video_widget)
+
+        self.image_label = QLabel(self)
+        self.image_label.setAlignment(Qt.AlignCenter)
+        self.image_label.setScaledContents(True)
+        self.image_label.hide()
+        container_layout.addWidget(self.image_label)
+        self.setCentralWidget(container)
 
         self.media_player = QMediaPlayer(self)
         self.media_player.setAudioOutput(self.audio_output)
@@ -391,21 +429,38 @@ class Player(QMainWindow):  # type: ignore[misc]
 
     def load_current_media(self, start_paused: bool = False) -> None:
         url = QUrl.fromLocalFile(str(self.current_file.resolve(strict=True)))
-        self.media_player.setSource(url)
+        if self.current_slide_config.type == SlideType.Video:
+            self.media_player.setSource(url)
 
-        if self.playing_reversed_slide:
-            self.media_player.setPlaybackRate(
-                self.current_slide_config.reversed_playback_rate * self.playback_rate
-            )
-        else:
-            self.media_player.setPlaybackRate(
-                self.current_slide_config.playback_rate * self.playback_rate
-            )
+            self.image_label.hide()
+            self.video_widget.show()
+            self.info.main_image_label.hide()
+            self.info.main_video_widget.show()
 
-        if start_paused:
-            self.media_player.pause()
+            if self.playing_reversed_slide:
+                self.media_player.setPlaybackRate(
+                    self.current_slide_config.reversed_playback_rate * self.playback_rate
+                )
+            else:
+                self.media_player.setPlaybackRate(
+                    self.current_slide_config.playback_rate * self.playback_rate
+                )
+
+            if start_paused:
+                self.media_player.pause()
+            else:
+                self.media_player.play()
         else:
-            self.media_player.play()
+            self.image_label.setPixmap(QPixmap(url.toLocalFile()))
+            self.info.main_image_label.setPixmap(QPixmap(url.toLocalFile()))
+
+            self.media_player.stop()
+
+            self.image_label.show()
+            self.video_widget.hide()
+            self.info.main_image_label.show()
+            self.info.main_video_widget.hide()
+
 
     def load_current_slide(self) -> None:
         slide_config = self.current_slide_config
@@ -476,8 +531,17 @@ class Player(QMainWindow):  # type: ignore[misc]
     def preview_next_slide(self) -> None:
         if slide_config := self.next_slide_config:
             url = QUrl.fromLocalFile(str(slide_config.file.resolve(strict=True)))
-            self.info.next_media_player.setSource(url)
-            self.info.next_media_player.play()
+            if self.next_slide_config.type == SlideType.Video:
+                self.info.next_video_widget.show()
+                self.info.next_image_label.hide()
+                self.info.next_media_player.setSource(url)
+                self.info.next_media_player.play()
+            else:
+                self.info.next_video_widget.hide()
+                self.info.next_image_label.show()
+                self.info.next_media_player.stop()
+                self.info.next_image_label.setPixmap(QPixmap(url.toLocalFile()))
+
 
     def show(self, screens: list[QScreen]) -> None:
         """Screens is necessary to prevent the info window from being shown on the same screen as the main window (especially in full screen mode)."""

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -10,6 +10,7 @@ from qtpy.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QMainWindow,
+    QStackedWidget,
     QVBoxLayout,
     QWidget,
 )
@@ -59,7 +60,8 @@ class Info(QWidget):  # type: ignore[misc]
 
         self.main_image_label = QLabel()
         self.main_image_label.setAlignment(Qt.AlignCenter)
-        self.main_image_label.setScaledContents(True)
+        self.main_image_label.setScaledContents(False)
+        self.main_image_label.setMinimumSize(720, 480)
         self.main_image_label.hide()
         current_layout.addWidget(self.main_image_label)
 
@@ -135,7 +137,8 @@ class Info(QWidget):  # type: ignore[misc]
 
         self.next_image_label = QLabel()
         self.next_image_label.setAlignment(Qt.AlignCenter)
-        self.next_image_label.setScaledContents(True)
+        self.next_image_label.setScaledContents(False)
+        self.next_image_label.setMinimumSize(360, 240)
         self.next_image_label.hide()
         perview_layout.addWidget(self.next_image_label)
 
@@ -252,20 +255,20 @@ class Player(QMainWindow):  # type: ignore[misc]
         self.video_widget = QVideoWidget()
         self.video_sink = self.video_widget.videoSink()
         self.video_widget.setAspectRatioMode(aspect_ratio_mode)
-        # self.setCentralWidget(self.video_widget)
-
-        container = QWidget()
-        container_layout = QVBoxLayout(container)
-        container_layout.setContentsMargins(0, 0, 0, 0)
-
-        container_layout.addWidget(self.video_widget)
 
         self.image_label = QLabel(self)
         self.image_label.setAlignment(Qt.AlignCenter)
-        self.image_label.setScaledContents(True)
-        self.image_label.hide()
-        container_layout.addWidget(self.image_label)
-        self.setCentralWidget(container)
+        self.image_label.setScaledContents(False)
+        w, h = self.current_presentation_config.resolution
+        self.image_label.setMinimumSize(w, h)
+
+        # Use QStackedWidget to switch between video and image without layout recalculation
+        self.media_stack = QStackedWidget()
+        self.media_stack.addWidget(self.video_widget)
+        self.media_stack.addWidget(self.image_label)
+        self.media_stack.setCurrentWidget(self.video_widget)
+
+        self.setCentralWidget(self.media_stack)
 
         self.media_player = QMediaPlayer(self)
         self.media_player.setAudioOutput(self.audio_output)
@@ -428,11 +431,13 @@ class Player(QMainWindow):  # type: ignore[misc]
 
     def load_current_media(self, start_paused: bool = False) -> None:
         url = QUrl.fromLocalFile(str(self.current_file.resolve(strict=True)))
-        if self.current_slide_config.type == SlideType.Video:
+        if self.current_slide_config.type == SlideType.Video or (
+            self.current_slide_config.type == SlideType.Image
+            and self.current_file.suffix.lower() == ".gif"
+        ):
             self.media_player.setSource(url)
 
-            self.image_label.hide()
-            self.video_widget.show()
+            self.media_stack.setCurrentWidget(self.video_widget)
             self.info.main_image_label.hide()
             self.info.main_video_widget.show()
 
@@ -451,13 +456,15 @@ class Player(QMainWindow):  # type: ignore[misc]
             else:
                 self.media_player.play()
         else:
-            self.image_label.setPixmap(QPixmap(url.toLocalFile()))
-            self.info.main_image_label.setPixmap(QPixmap(url.toLocalFile()))
+            w, _ = self.current_presentation_config.resolution
+            pixmap = QPixmap(url.toLocalFile())
+            scaled_pixmap = pixmap.scaledToWidth(w)
+            self.image_label.setPixmap(scaled_pixmap)
+            self.info.main_image_label.setPixmap(scaled_pixmap)
 
             self.media_player.stop()
 
-            self.image_label.show()
-            self.video_widget.hide()
+            self.media_stack.setCurrentWidget(self.image_label)
             self.info.main_image_label.show()
             self.info.main_video_widget.hide()
 
@@ -539,7 +546,10 @@ class Player(QMainWindow):  # type: ignore[misc]
                 self.info.next_video_widget.hide()
                 self.info.next_image_label.show()
                 self.info.next_media_player.stop()
-                self.info.next_image_label.setPixmap(QPixmap(url.toLocalFile()))
+                w, _ = self.current_presentation_config.resolution
+                pixmap = QPixmap(url.toLocalFile())
+                scaled_pixmap = pixmap.scaledToWidth(w)
+                self.info.next_image_label.setPixmap(scaled_pixmap)
 
     def show(self, screens: list[QScreen]) -> None:
         """Screens is necessary to prevent the info window from being shown on the same screen as the main window (especially in full screen mode)."""

--- a/manim_slides/slide/base.py
+++ b/manim_slides/slide/base.py
@@ -575,7 +575,7 @@ class BaseSlide:
                 slide_files = files[pre_slide_config.slides_slice]
 
             try:
-                if pre_slide_config.type is SlideType.Video:
+                if pre_slide_config.type == SlideType.Video:
                     file = merge_basenames(slide_files)
                 else:
                     file = Path(slide_files[0])
@@ -592,7 +592,7 @@ class BaseSlide:
 
             # We only reverse video if it was not present and not a static image
             if not use_cache or not rev_file.exists():
-                if skip_reversing or pre_slide_config.type is SlideType.Image:
+                if skip_reversing or pre_slide_config.type == SlideType.Image:
                     rev_file = dst_file
                 else:
                     reverse_video_file(

--- a/manim_slides/slide/base.py
+++ b/manim_slides/slide/base.py
@@ -15,7 +15,7 @@ from typing import (
 import numpy as np
 from tqdm import tqdm
 
-from ..config import BaseSlideConfig, PresentationConfig, PreSlideConfig, SlideConfig
+from ..config import BaseSlideConfig, PresentationConfig, PreSlideConfig, SlideConfig, SlideType
 from ..defaults import FOLDER_PATH
 from ..logger import logger
 from ..utils import concatenate_video_files, merge_basenames, reverse_video_file
@@ -484,7 +484,6 @@ class BaseSlide:
 
         if (
             base_slide_config.src is not None
-            or base_slide_config.static_image is not None
         ):
             self._slides.append(
                 PreSlideConfig.from_base_slide_config_and_animation_indices(
@@ -568,13 +567,11 @@ class BaseSlide:
                 continue
             if pre_slide_config.src:
                 slide_files = [pre_slide_config.src]
-            if pre_slide_config.static_image:
-                slide_files = [pre_slide_config.static_image]
             else:
                 slide_files = files[pre_slide_config.slides_slice]
 
             try:
-                if pre_slide_config.src is not None:
+                if pre_slide_config.type is SlideType.Video:
                     file = merge_basenames(slide_files)
                 else:
                     file = Path(slide_files[0])
@@ -591,7 +588,7 @@ class BaseSlide:
 
             # We only reverse video if it was not present and not a static image
             if not use_cache or not rev_file.exists():
-                if skip_reversing or pre_slide_config.static_image is not None:
+                if skip_reversing or pre_slide_config.type is SlideType.Image:
                     rev_file = dst_file
                 else:
                     reverse_video_file(

--- a/manim_slides/slide/base.py
+++ b/manim_slides/slide/base.py
@@ -15,7 +15,13 @@ from typing import (
 import numpy as np
 from tqdm import tqdm
 
-from ..config import BaseSlideConfig, PresentationConfig, PreSlideConfig, SlideConfig, SlideType
+from ..config import (
+    BaseSlideConfig,
+    PresentationConfig,
+    PreSlideConfig,
+    SlideConfig,
+    SlideType,
+)
 from ..defaults import FOLDER_PATH
 from ..logger import logger
 from ..utils import concatenate_video_files, merge_basenames, reverse_video_file
@@ -482,9 +488,7 @@ class BaseSlide:
 
             self._current_slide += 1
 
-        if (
-            base_slide_config.src is not None
-        ):
+        if base_slide_config.src is not None:
             self._slides.append(
                 PreSlideConfig.from_base_slide_config_and_animation_indices(
                     base_slide_config,

--- a/manim_slides/slide/base.py
+++ b/manim_slides/slide/base.py
@@ -482,7 +482,10 @@ class BaseSlide:
 
             self._current_slide += 1
 
-        if base_slide_config.src is not None or base_slide_config.static_image is not None:
+        if (
+            base_slide_config.src is not None
+            or base_slide_config.static_image is not None
+        ):
             self._slides.append(
                 PreSlideConfig.from_base_slide_config_and_animation_indices(
                     base_slide_config,

--- a/manim_slides/slide/base.py
+++ b/manim_slides/slide/base.py
@@ -482,7 +482,7 @@ class BaseSlide:
 
             self._current_slide += 1
 
-        if base_slide_config.src is not None:
+        if base_slide_config.src is not None or base_slide_config.static_image is not None:
             self._slides.append(
                 PreSlideConfig.from_base_slide_config_and_animation_indices(
                     base_slide_config,
@@ -565,11 +565,16 @@ class BaseSlide:
                 continue
             if pre_slide_config.src:
                 slide_files = [pre_slide_config.src]
+            if pre_slide_config.static_image:
+                slide_files = [pre_slide_config.static_image]
             else:
                 slide_files = files[pre_slide_config.slides_slice]
 
             try:
-                file = merge_basenames(slide_files)
+                if pre_slide_config.src is not None:
+                    file = merge_basenames(slide_files)
+                else:
+                    file = Path(slide_files[0])
             except ValueError as e:
                 raise ValueError(
                     f"Failed to merge basenames of files for slide: {pre_slide_config!r}"
@@ -581,9 +586,9 @@ class BaseSlide:
             if not use_cache or not dst_file.exists():
                 concatenate_video_files(slide_files, dst_file)
 
-            # We only reverse video if it was not present
+            # We only reverse video if it was not present and not a static image
             if not use_cache or not rev_file.exists():
-                if skip_reversing:
+                if skip_reversing or pre_slide_config.static_image is not None:
                     rev_file = dst_file
                 else:
                     reverse_video_file(

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -42,7 +42,7 @@
           data-background-size={{ background_size }}
           data-background-color="{{ presentation_config.background_color }}"
           {% if slide_config.type.value == "image" %}
-          data-background-image="{{file}}"
+          data-background-image="{{ file }}"
           {% else %}
           data-background-video="{{ file }}"
           {% if loop.index == 1 and outer_loop.index == 1 %}
@@ -290,7 +290,7 @@
         },
         () => {
           var currentVideos = Reveal.getCurrentSlide().slideBackgroundContentElement.getElementsByTagName("video");
-          if (currentVideos.length > 0 && currentImage != null) {
+          if (currentVideos.length > 0) {
             if (currentVideos[0].paused == true) currentVideos[0].play();
             else currentVideos[0].pause();
           } else {

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -41,7 +41,7 @@
         <section
           data-background-size={{ background_size }}
           data-background-color="{{ presentation_config.background_color }}"
-          {% if slide_config.type == SlideType.Image %}
+          {% if slide_config.type.value == "image" %}
           data-background-image="{{file}}"
           {% else %}
           data-background-video="{{ file }}"

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -41,12 +41,16 @@
         <section
           data-background-size={{ background_size }}
           data-background-color="{{ presentation_config.background_color }}"
+          {% if slide_config.static_image %}
+          data-background-image="{{file}}"
+          {% else %}
           data-background-video="{{ file }}"
           {% if loop.index == 1 and outer_loop.index == 1 %}
           data-background-video-muted
           {% endif %}
           {% if slide_config.loop %}
           data-background-video-loop
+          {% endif %}
           {% endif %}
           {% if slide_config.auto_next %}
           data-autoslide="{{ get_duration_ms(slide_config.file) }}"

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -25,7 +25,7 @@
             {% if one_file %}
               {% set file = file_to_data_uri(slide_config.file) %}
             {% else %}
-              {% set file = assets_dir / (prefix(outer_loop.index0) + slide_config.file.name) %}
+              {% set file = assets_dir+ '/' +(prefix(outer_loop.index0) + slide_config.file.name) %}
             {% endif %}
             {% if slide_config.direction == "vertical" %}
               {% if not ns.open_stack %}
@@ -41,7 +41,7 @@
         <section
           data-background-size={{ background_size }}
           data-background-color="{{ presentation_config.background_color }}"
-          {% if slide_config.static_image %}
+          {% if slide_config.type == SlideType.Image %}
           data-background-image="{{file}}"
           {% else %}
           data-background-video="{{ file }}"
@@ -290,7 +290,7 @@
         },
         () => {
           var currentVideos = Reveal.getCurrentSlide().slideBackgroundContentElement.getElementsByTagName("video");
-          if (currentVideos.length > 0) {
+          if (currentVideos.length > 0 && currentImage != null) {
             if (currentVideos[0].paused == true) currentVideos[0].play();
             else currentVideos[0].pause();
           } else {

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -25,7 +25,7 @@
             {% if one_file %}
               {% set file = file_to_data_uri(slide_config.file) %}
             {% else %}
-              {% set file = assets_dir+ '/' +(prefix(outer_loop.index0) + slide_config.file.name) %}
+              {% set file = assets_dir ~ '/' ~ (prefix(outer_loop.index0) + slide_config.file.name) %}
             {% endif %}
             {% if slide_config.direction == "vertical" %}
               {% if not ns.open_stack %}

--- a/manim_slides/utils.py
+++ b/manim_slides/utils.py
@@ -89,7 +89,7 @@ def merge_basenames(files: list[Path]) -> Path:
     """Merge multiple filenames by concatenating basenames."""
     if len(files) == 0:
         raise ValueError("Cannot merge an empty list of files!")
-        
+
     dirname: Path = files[0].parent
     ext = files[0].suffix
 

--- a/manim_slides/utils.py
+++ b/manim_slides/utils.py
@@ -89,7 +89,7 @@ def merge_basenames(files: list[Path]) -> Path:
     """Merge multiple filenames by concatenating basenames."""
     if len(files) == 0:
         raise ValueError("Cannot merge an empty list of files!")
-
+        
     dirname: Path = files[0].parent
     ext = files[0].suffix
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from manim_slides.config import Key, PresentationConfig
+from manim_slides.config import Key, PresentationConfig,SlideType,BaseSlideConfig
 
 
 class TestKey:
@@ -30,3 +30,10 @@ class TestPresentationConfig:
     def test_empty_presentation_config(self) -> None:
         with pytest.raises(ValidationError):
             _ = PresentationConfig(slides=[], files=[])
+
+class TestBaseSlideConfig:
+    @pytest.mark.parametrize(("src","expected_type"), [("test.png",SlideType.Image),("test.mp4",SlideType.Video),(None,SlideType.Video)])
+    def test_determine_slide_type(self,src: Any,expected_type:Any) -> None:
+        obj = BaseSlideConfig(src = src)
+        assert obj.type == expected_type
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -41,7 +42,10 @@ class TestBaseSlideConfig:
             (None, SlideType.Video),
         ],
     )
-    def test_determine_slide_type(self, src: Any, expected_type: Any) -> None:
+    def test_determine_slide_type(self, src: Any, expected_type: Any, tmp_path: Path) -> None:
+        if src is not None:
+            src = tmp_path / src
+            src.touch()  # create the file
         obj = BaseSlideConfig(src=src)
         if obj.type != expected_type:
             raise AssertionError(f"Expected {expected_type}, got {obj.type}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,5 +35,5 @@ class TestBaseSlideConfig:
     @pytest.mark.parametrize(("src","expected_type"), [("test.png",SlideType.Image),("test.mp4",SlideType.Video),(None,SlideType.Video)])
     def test_determine_slide_type(self,src: Any,expected_type:Any) -> None:
         obj = BaseSlideConfig(src = src)
-        assert obj.type == expected_type
-
+        if obj.type != expected_type :
+            raise AssertionError(f"Expected {expected_type}, got {obj.type}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,7 +42,9 @@ class TestBaseSlideConfig:
             (None, SlideType.Video),
         ],
     )
-    def test_determine_slide_type(self, src: Any, expected_type: Any, tmp_path: Path) -> None:
+    def test_determine_slide_type(
+        self, src: Any, expected_type: Any, tmp_path: Path
+    ) -> None:
         if src is not None:
             src = tmp_path / src
             src.touch()  # create the file

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from manim_slides.config import Key, PresentationConfig,SlideType,BaseSlideConfig
+from manim_slides.config import BaseSlideConfig, Key, PresentationConfig, SlideType
 
 
 class TestKey:
@@ -31,9 +31,16 @@ class TestPresentationConfig:
         with pytest.raises(ValidationError):
             _ = PresentationConfig(slides=[], files=[])
 
-class TestBaseSlideConfig:
-    @pytest.mark.parametrize(("src","expected_type"), [("test.png",SlideType.Image),("test.mp4",SlideType.Video),(None,SlideType.Video)])
-    def test_determine_slide_type(self,src: Any,expected_type:Any) -> None:
-        obj = BaseSlideConfig(src = src)
-        assert obj.type == expected_type
 
+class TestBaseSlideConfig:
+    @pytest.mark.parametrize(
+        ("src", "expected_type"),
+        [
+            ("test.png", SlideType.Image),
+            ("test.mp4", SlideType.Video),
+            (None, SlideType.Video),
+        ],
+    )
+    def test_determine_slide_type(self, src: Any, expected_type: Any) -> None:
+        obj = BaseSlideConfig(src=src)
+        assert obj.type == expected_type

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,6 +43,5 @@ class TestBaseSlideConfig:
     )
     def test_determine_slide_type(self, src: Any, expected_type: Any) -> None:
         obj = BaseSlideConfig(src=src)
-        if obj.type != expected_type :
+        if obj.type != expected_type:
             raise AssertionError(f"Expected {expected_type}, got {obj.type}")
-


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #553

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Description

- Updated `BaseSlideConfig` to support `static_image` field
- Refactored `_save_slides` to handle `static_image`
- Updated `convert.py` and `revealjs.html` to support `static_image`

<!-- Describe all the proposed changes in your PR -->

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->
<img width="1920" height="1020" alt="{B6333D2F-0C72-4507-96F7-2A11B52E880D}" src="https://github.com/user-attachments/assets/b2af3bcd-3253-42c2-9ecc-89b9abb26102" />

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
