### PR TITLE
chore(html): bump RevealJS default version to v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Chore
 
-- Changed default RevealJS version to 6.0.1. Update the templates accordingly, and remove the use of minified versions, as they are no longer provided by the CDN.
+- Changed default RevealJS version to 6.0.1. Updated the templates accordingly, and removed the use of minified versions, as they are no longer provided by the CDN.
   [#618](https://github.com/jeertmans/manim-slides/pull/618)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added vertical slide implementation to html exports of presentations. [@DaughterOfSpring](https://github.com/daughterOfSpring) [#602](https://github.com/jeertmans/manim-slides/pull/602)
+- Added option to specify the CDN from which to load RevealJS, and changed the default CDN, see [hakimel/reveal.js#3894](https://github.com/hakimel/reveal.js/issues/3894) for more details.
+  [#618](https://github.com/jeertmans/manim-slides/pull/618)
+
+### Chore
+
+- Changed default RevealJS version to 6.0.1. Update the templates accordingly, and remove the use of minified versions, as they are no longer provided by the CDN.
+  [#618](https://github.com/jeertmans/manim-slides/pull/618)
 
 ### Fixed
 

--- a/docs/source/_static/template.html
+++ b/docs/source/_static/template.html
@@ -6,13 +6,11 @@
 
     <title>{{ title }}</title>
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/reveal.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/theme/{{ reveal_theme }}.min.css">
+    <link rel="stylesheet" href="{{ cdn_url }}/dist/reveal.css">
+    <link rel="stylesheet" href="{{ cdn_url }}/dist/theme/{{ reveal_theme }}.css">
 
     <!-- Theme used for syntax highlighting of code -->
-    <!-- <link rel="stylesheet" href="lib/css/zenburn.css"> -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/zenburn.min.css">
-    <!-- <link rel="stylesheet" href="index.css"> -->
+    <link rel="stylesheet" href="{{ cdn_url }}/dist/plugin/highlight/zenburn.css">
   </head>
 
   <body>
@@ -49,12 +47,12 @@
       </div>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/reveal.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/plugin/notes/notes.min.js"></script>
+    <script src="{{ cdn_url }}/dist/reveal.js"></script>
+    <script src="{{ cdn_url }}/dist/plugin/notes.js"></script>
 
     <!-- To include plugins, see: https://revealjs.com/plugins/ -->
     {% if has_notes %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/plugin/markdown/markdown.min.js"></script>
+    <script src="{{ cdn_url }}/dist/plugin/markdown.js"></script>
     {% endif %}
 
     <!-- <script src="index.js"></script> -->

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -531,9 +531,13 @@ class RevealJS(Converter):
         "black",
         description="Background color used in slides, not relevant if videos fill the whole area.",
     )
-    reveal_version: str = Field("5.2.0", description="RevealJS version.")
+    reveal_version: str = Field("6.0.1", description="RevealJS version.")
     reveal_theme: RevealTheme = Field(
         RevealTheme.black, description="RevealJS version."
+    )
+    cdn_url: str = Field(
+        "https://cdn.jsdelivr.net/npm/reveal.js@{reveal_version}",
+        description="CDN URL to load RevealJS assets from. Known CDNs include https://cdn.jsdelivr.net/npm/reveal.js@{reveal_version}, https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{reveal_version}, or https://unpkg.com/reveal.js@{reveal_version}.",
     )
     title: str = Field("Manim Slides", description="Presentation title.")
     # Pydantic options
@@ -599,6 +603,10 @@ class RevealJS(Converter):
             )
 
             options = self.model_dump()
+
+            options["cdn_url"] = options["cdn_url"].format(
+                reveal_version=options["reveal_version"]
+            )
 
             if assets_dir is not None:
                 options["assets_dir"] = assets_dir

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -162,7 +162,7 @@ class Player(QMainWindow):  # type: ignore[misc]
     presentation_changed: Signal = Signal()
     slide_changed: Signal = Signal()
 
-    def __init__(  # noqa: C901
+    def __init__(
         self,
         config: Config,
         presentation_configs: list[PresentationConfig],

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -162,7 +162,7 @@ class Player(QMainWindow):  # type: ignore[misc]
     presentation_changed: Signal = Signal()
     slide_changed: Signal = Signal()
 
-    def __init__(
+    def __init__(  # noqa: C901
         self,
         config: Config,
         presentation_configs: list[PresentationConfig],

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -6,12 +6,12 @@
 
     <title>{{ title }}</title>
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/reveal.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/theme/{{ reveal_theme }}.min.css">
+    <link rel="stylesheet" href="{{ cdn_url }}/dist/reveal.css">
+    <link rel="stylesheet" href="{{ cdn_url }}/dist/theme/{{ reveal_theme }}.css">
 
     <!-- Theme used for syntax highlighting of code -->
     <!-- <link rel="stylesheet" href="lib/css/zenburn.css"> -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/zenburn.min.css">
+    <link rel="stylesheet" href="{{ cdn_url }}/dist/plugin/highlight/zenburn.css">
     <!-- <link rel="stylesheet" href="index.css"> -->
   </head>
 
@@ -64,12 +64,12 @@
       </div>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/reveal.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/plugin/notes/notes.min.js"></script>
+    <script src="{{ cdn_url }}/dist/reveal.js"></script>
+    <script src="{{ cdn_url }}/dist/plugin/notes.js"></script>
 
     <!-- To include plugins, see: https://revealjs.com/plugins/ -->
     {% if has_notes %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/{{ reveal_version }}/plugin/markdown/markdown.min.js"></script>
+    <script src="{{ cdn_url }}/dist/plugin/markdown.js"></script>
     {% endif %}
 
     <!-- <script src="index.js"></script> -->

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -168,10 +168,10 @@ class TestConverter:
         assets_dir = Path(tmp_path / "slides_assets")
         assert assets_dir.is_dir()
         for file in [
-            "black.min.css",
-            "reveal.min.css",
-            "reveal.min.js",
-            "zenburn.min.css",
+            "black.css",
+            "reveal.css",
+            "reveal.js",
+            "zenburn.css",
         ]:
             assert (assets_dir / file).exists()
 


### PR DESCRIPTION
Closes #617 and #615.
