### PR TITLE
feat(lib/present/html): implement slide id field and jump-to feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 (unreleased)=
 ## [Unreleased](https://github.com/jeertmans/manim-slides/compare/v5.6.0...HEAD)
 
+### Added
+
+- Added slide id field and "jump-to" feature in present mode (#635)
+
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)
 

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -179,6 +179,13 @@ class BaseSlideConfig(BaseModel):  # type: ignore
     type: SlideType = SlideType.Video
     direction: Literal["horizontal", "vertical"] = "horizontal"
 
+    @field_validator("id")
+    @classmethod
+    def process_id(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None:
+            return v.strip().lower()
+        return v
+
     @model_validator(mode="after")
     def determine_slide_type(self) -> "BaseSlideConfig":
         """Determine the type of src."""
@@ -329,6 +336,13 @@ class PresentationConfig(BaseModel):  # type: ignore[misc]
     slides: list[SlideConfig] = Field(min_length=1)
     resolution: tuple[PositiveInt, PositiveInt] = (1920, 1080)
     background_color: Color = "black"
+
+    @model_validator(mode="after")
+    def ids_are_unique(self) -> "PresentationConfig":
+        ids = [s.id for s in self.slides if s.id is not None]
+        if len(ids) != len(set(ids)):
+            logger.warning("Duplicate slide IDs found. Some IDs may be unreachable.")
+        return self
 
     @classmethod
     def from_file(cls, path: Path) -> "PresentationConfig":

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -100,7 +100,9 @@ class Keys(BaseModel):  # type: ignore[misc]
     FULL_SCREEN: Key = Field(
         default_factory=lambda: Key(ids=[key_id("F")], name="TOGGLE FULL SCREEN")
     )
-    JUMP: Key = Field(default_factory=lambda: Key(ids=[key_id("G")], name="JUMP TO SLIDE")) 
+    JUMP: Key = Field(
+        default_factory=lambda: Key(ids=[key_id("G")], name="JUMP TO SLIDE")
+    )
 
     HIDE_MOUSE: Key = Field(
         default_factory=lambda: Key(ids=[key_id("H")], name="HIDE / SHOW MOUSE")
@@ -164,6 +166,7 @@ class Config(BaseModel):  # type: ignore[misc]
 
 class BaseSlideConfig(BaseModel):  # type: ignore
     """Base class for slide config."""
+
     id: Optional[str] = None
     loop: bool = False
     auto_next: bool = False

--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -100,6 +100,8 @@ class Keys(BaseModel):  # type: ignore[misc]
     FULL_SCREEN: Key = Field(
         default_factory=lambda: Key(ids=[key_id("F")], name="TOGGLE FULL SCREEN")
     )
+    JUMP: Key = Field(default_factory=lambda: Key(ids=[key_id("G")], name="JUMP TO SLIDE")) 
+
     HIDE_MOUSE: Key = Field(
         default_factory=lambda: Key(ids=[key_id("H")], name="HIDE / SHOW MOUSE")
     )
@@ -162,7 +164,7 @@ class Config(BaseModel):  # type: ignore[misc]
 
 class BaseSlideConfig(BaseModel):  # type: ignore
     """Base class for slide config."""
-
+    id: Optional[str] = None
     loop: bool = False
     auto_next: bool = False
     playback_rate: float = 1.0

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -8,12 +8,12 @@ from qtpy.QtMultimedia import QAudioOutput, QMediaPlayer, QVideoFrame
 from qtpy.QtMultimediaWidgets import QVideoWidget
 from qtpy.QtWidgets import (
     QHBoxLayout,
+    QInputDialog,
     QLabel,
     QMainWindow,
     QStackedWidget,
     QVBoxLayout,
     QWidget,
-    QInputDialog,
 )
 
 from ..config import Config, PresentationConfig, SlideConfig, SlideType
@@ -521,11 +521,12 @@ class Player(QMainWindow):  # type: ignore[misc]
     """
     Key callbacks and slots
     """
+
     @Slot()
     def jump_to_slide(self) -> None:
         # Ask the user for the target slide ID
         target_id, ok = QInputDialog.getText(self, "Jump to Slide", "Enter Slide ID:")
-        
+
         if ok and target_id:
             # Search for the slide with the given ID
             for p_idx, presentation in enumerate(self.presentation_configs):
@@ -537,8 +538,9 @@ class Player(QMainWindow):  # type: ignore[misc]
                         self.load_current_slide()
                         logger.info(f"Jumped to slide ID: {target_id}")
                         return
-            
+
             logger.warning(f"Slide ID '{target_id}' not found.")
+
     @Slot()
     def presentation_changed_callback(self) -> None:
         index = self.current_presentation_index

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -13,6 +13,7 @@ from qtpy.QtWidgets import (
     QStackedWidget,
     QVBoxLayout,
     QWidget,
+    QInputDialog,
 )
 
 from ..config import Config, PresentationConfig, SlideConfig, SlideType
@@ -297,6 +298,7 @@ class Player(QMainWindow):  # type: ignore[misc]
         self.config.keys.REPLAY.connect(self.replay)
         self.config.keys.FULL_SCREEN.connect(self.full_screen)
         self.config.keys.HIDE_MOUSE.connect(self.hide_mouse)
+        self.config.keys.JUMP.connect(self.jump_to_slide)
 
         self.dispatch = self.config.keys.dispatch_key_function()
 
@@ -519,7 +521,24 @@ class Player(QMainWindow):  # type: ignore[misc]
     """
     Key callbacks and slots
     """
-
+    @Slot()
+    def jump_to_slide(self) -> None:
+        # Ask the user for the target slide ID
+        target_id, ok = QInputDialog.getText(self, "Jump to Slide", "Enter Slide ID:")
+        
+        if ok and target_id:
+            # Search for the slide with the given ID
+            for p_idx, presentation in enumerate(self.presentation_configs):
+                for s_idx, slide in enumerate(presentation.slides):
+                    if slide.id == target_id:
+                        # Found the target slide, jump to it
+                        self.current_presentation_index = p_idx
+                        self.current_slide_index = s_idx
+                        self.load_current_slide()
+                        logger.info(f"Jumped to slide ID: {target_id}")
+                        return
+            
+            logger.warning(f"Slide ID '{target_id}' not found.")
     @Slot()
     def presentation_changed_callback(self) -> None:
         index = self.current_presentation_index

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -528,6 +528,7 @@ class Player(QMainWindow):  # type: ignore[misc]
         target_id, ok = QInputDialog.getText(self, "Jump to Slide", "Enter Slide ID:")
 
         if ok and target_id:
+            target_id = target_id.strip().lower()
             # Search for the slide with the given ID
             for p_idx, presentation in enumerate(self.presentation_configs):
                 for s_idx, slide in enumerate(presentation.slides):
@@ -536,10 +537,10 @@ class Player(QMainWindow):  # type: ignore[misc]
                         self.current_presentation_index = p_idx
                         self.current_slide_index = s_idx
                         self.load_current_slide()
-                        logger.info(f"Jumped to slide ID: {target_id}")
+                        logger.info(f"Jumped to slide {target_id!r}")
                         return
 
-            logger.warning(f"Slide ID '{target_id}' not found.")
+            logger.warning(f"Slide ID {target_id!r} not found.")
 
     @Slot()
     def presentation_changed_callback(self) -> None:

--- a/manim_slides/slide/base.py
+++ b/manim_slides/slide/base.py
@@ -308,6 +308,9 @@ class BaseSlide:
             Positional arguments passed to
             :meth:`Scene.next_section<manim.scene.scene.Scene.next_section>`,
             or ignored if `manimlib` API is used.
+        :param id:
+            An optional unique identifier for the slide, which can be used 
+            to jump directly to this slide during a presentation.
         :param skip_animations:
             Exclude the next slide from the output.
 

--- a/manim_slides/slide/base.py
+++ b/manim_slides/slide/base.py
@@ -309,7 +309,7 @@ class BaseSlide:
             :meth:`Scene.next_section<manim.scene.scene.Scene.next_section>`,
             or ignored if `manimlib` API is used.
         :param id:
-            An optional unique identifier for the slide, which can be used 
+            An optional unique identifier for the slide, which can be used
             to jump directly to this slide during a presentation.
         :param skip_animations:
             Exclude the next slide from the output.

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -39,6 +39,7 @@
             {% endif %}
           {% endif %}
         <section
+          {% if slide_config.id %}id="{{ slide_config.id }}"{% endif %}
           data-background-size={{ background_size }}
           data-background-color="{{ presentation_config.background_color }}"
           {% if slide_config.type.value == "image" %}


### PR DESCRIPTION
## Fixes Issue

Closes #332

## Description

This PR implements the requested "jump-to" feature and adds an `id` field to slides.

**Proposed changes:**
1. **Config:** Added an optional `id` field to `BaseSlideConfig` so users can name their slides.
2. **Key Bindings:** Added a new `JUMP` action to the `Keys` class, mapped to the `G` key by default.
3. **Presenter Logic:** Implemented `jump_to_slide` in the `Player` class. It opens a dialog to ask for a slide ID and jumps to the corresponding index if it exists.
4. **HTML Export:** Updated the RevealJS template to include the `id` attribute on slide sections, allowing direct linking in browsers.

## Check List

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add screenshots here if you have them, otherwise you can leave this empty -->

## Note to reviewers

I chose the 'G' key (for "Go to") as it's common in document viewers. The implementation uses `QInputDialog` for a native look and feel in the Qt presenter.