### PR TITLE
chore(docs): document ManimGL `Slide.wait()` workaround in FAQ

### DIFF
--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -71,7 +71,39 @@ the problem can be addressed by changing the scaling factor to 100%:
   >
 </p>
 
-in *Settings*->*Display*.
+in _Settings_->_Display_.
+
+### Why are there animation errors in slides when using `Slide.wait()` with ManimGL
+
+(manimgl-wait-workaround)=
+
+There is currently a known issue with the `Slide.wait()` method using ManimGL. A workaround has been found by [@marcell-ziegler](https://github.com/marcell-ziegler) in [#609](https://github.com/jeertmans/manim-slides/issues/609).
+
+To have a working wait method, you need to crate an {py:class}`Animation<manimlib.Animation>` which does nothing for the specified amount of time. To do this, declare this class early in your code:
+
+```python
+class Wait(Animation):
+    def __init__(self, run_time: float = 1.0):
+        super().__init__(
+            Group(), run_time=run_time, remover=True, name=f"Wait({run_time})"
+        )
+```
+
+Then, in you {py:class}`Slide<manim_slides.slide.Slide>` class, override the `Slide.wait()` method like this:
+
+```python
+class MySlide(Slide):
+
+    @override
+    def wait(self, duration=None) -> None:
+        wait_time = self.default_wait_time if duration is None else duration
+        self.play(Wait(wait_time))
+
+    def construct(self):
+        ...
+```
+
+Now you just call the new `Slide.wait()` anywhere in your constructor and it should work fine.
 
 ## Converting to any format
 

--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -77,9 +77,14 @@ in _Settings_->_Display_.
 
 (manimgl-wait-workaround)=
 
-There is currently a known issue with the `Slide.wait()` method using ManimGL. A workaround has been found by [@marcell-ziegler](https://github.com/marcell-ziegler) in [#609](https://github.com/jeertmans/manim-slides/issues/609).
+There is currently a known issue with the `Slide.wait()` method using ManimGL.
+A workaround has been found by
+[@marcell-ziegler](https://github.com/marcell-ziegler),
+in [#609](https://github.com/jeertmans/manim-slides/issues/609).
 
-To have a working wait method, you need to crate an {py:class}`Animation<manimlib.Animation>` which does nothing for the specified amount of time. To do this, declare this class early in your code:
+To have a working wait method, you need to crate an
+{py:class}`Animation<manimlib.Animation>` which does nothing for the
+specified amount of time. To do this, declare this class early in your code:
 
 ```python
 class Wait(Animation):
@@ -89,7 +94,8 @@ class Wait(Animation):
         )
 ```
 
-Then, in you {py:class}`Slide<manim_slides.slide.Slide>` class, override the `Slide.wait()` method like this:
+Then, in you {py:class}`Slide<manim_slides.slide.Slide>` class,
+override the `Slide.wait()` method like this:
 
 ```python
 class MySlide(Slide):
@@ -103,7 +109,8 @@ class MySlide(Slide):
         ...
 ```
 
-Now you just call the new `Slide.wait()` anywhere in your constructor and it should work fine.
+Now you just call the new `Slide.wait()` anywhere in your constructor
+and it should work fine.
 
 ## Converting to any format
 

--- a/docs/source/manim_or_manimgl.md
+++ b/docs/source/manim_or_manimgl.md
@@ -68,3 +68,7 @@ if any of the two modules is already imported.
 
 If you want to force Manim Slides to obey the `MANIM_API` environment variable,
 you must also set `FORCE_MANIM_API=1`.
+
+## Current state of the `Slide.wait()` method in ManimGL
+
+Currently, there is a known issue with this method that can cause rendering issues when using the ManimGL backend. There is a workaround for dis described in the [FAQ](./faq.md#manimgl-wait-workaround)

--- a/docs/source/manim_or_manimgl.md
+++ b/docs/source/manim_or_manimgl.md
@@ -71,4 +71,6 @@ you must also set `FORCE_MANIM_API=1`.
 
 ## Current state of the `Slide.wait()` method in ManimGL
 
-Currently, there is a known issue with this method that can cause rendering issues when using the ManimGL backend. There is a workaround for dis described in the [FAQ](./faq.md#manimgl-wait-workaround)
+Currently, there is a known issue with this method that can cause
+rendering issues when using the ManimGL backend. There is a
+workaround for this described in the [FAQ](./faq.md#manimgl-wait-workaround)


### PR DESCRIPTION
Update the FAQ to include a workaround for the known issue with the `Slide.wait()` method in ManimGL. The workaround involves creating a custom `Wait` animation and overriding the `Slide.wait()` method in the user's slide class. This provides users with a solution to avoid rendering issues when using the ManimGL backend.

This PR aims to temporarily solve #609 while a permanent solution is implemented.