### PR TITLE
feat(lib): add wait_between_looping_slides to skip pause before looping slides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Firebase Realtime Database, including a usage guide in the templates
   directory. [@liuktc](https://github.com/liuktc) [#638](https://github.com/jeertmans/manim-slides/pull/638)
 - Added support for named built-in templates. Now `manim-slides convert` accepts the template name without the full path. [@liuktc](https://github.com/liuktc) [#638](https://github.com/jeertmans/manim-slides/pull/638)
-- Added `wait_between_looping_slides` property to skip the `wait_time_between_slides` pause before slides created with `next_slide(loop=True)`, avoiding a stutter on every loop repeat. [@zain-asif-dev](https://github.com/zain-asif-dev) [#648](https://github.com/jeertmans/manim-slides/pull/648)
+- Added `wait_between_looping_slides` property to skip the `wait_time_between_slides` pause inside slides created with `next_slide(loop=True)`, avoiding a stutter on every loop repeat. [@zain-asif-dev](https://github.com/zain-asif-dev) [#648](https://github.com/jeertmans/manim-slides/pull/648)
 
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Firebase Realtime Database, including a usage guide in the templates
   directory. [@liuktc](https://github.com/liuktc) [#638](https://github.com/jeertmans/manim-slides/pull/638)
 - Added support for named built-in templates. Now `manim-slides convert` accepts the template name without the full path. [@liuktc](https://github.com/liuktc) [#638](https://github.com/jeertmans/manim-slides/pull/638)
+- Added `wait_between_looping_slides` property to skip the `wait_time_between_slides` pause before slides created with `next_slide(loop=True)`, avoiding a stutter on every loop repeat. [@zain-asif-dev](https://github.com/zain-asif-dev) [#648](https://github.com/jeertmans/manim-slides/pull/648)
 
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)

--- a/docs/source/reference/api.md
+++ b/docs/source/reference/api.md
@@ -20,6 +20,7 @@ use, not the methods used internally when rendering.
         remove_from_canvas,
         start_skip_animations,
         stop_skip_animations,
+        wait_between_looping_slides,
         wait_time_between_slides,
         wipe,
         zoom,

--- a/manim_slides/slide/base.py
+++ b/manim_slides/slide/base.py
@@ -540,7 +540,7 @@ class BaseSlide:
         """
         if self._current_animation > self._start_animation:
             if self.wait_time_between_slides > 0.0 and (
-                self.wait_between_looping_slides or not self._base_slide_config.loop
+                not self._base_slide_config.loop or self.wait_between_looping_slides
             ):
                 self.wait(self.wait_time_between_slides)  # type: ignore[attr-defined]
 

--- a/manim_slides/slide/base.py
+++ b/manim_slides/slide/base.py
@@ -300,6 +300,48 @@ class BaseSlide:
         :attr:`wait_time_between_slides` right before a looping slide starts,
         which can otherwise be visible as an unwanted stutter every time the
         loop repeats.
+
+        Examples
+        --------
+        .. manim-slides:: WithWaitBetweenLoopingSlidesExample
+
+            from manim import *
+            from manim_slides import Slide
+
+            class WithWaitBetweenLoopingSlidesExample(Slide):
+                def construct(self):
+                    self.wait_time_between_slides = 0.5
+                    dot = Dot(color=BLUE, radius=1)
+
+                    self.play(FadeIn(dot))
+                    self.next_slide(loop=True)
+
+                    self.play(Indicate(dot, scale_factor=2))
+
+                    self.next_slide()
+
+                    self.play(FadeOut(dot))
+
+        .. manim-slides:: WithoutWaitBetweenLoopingSlidesExample
+
+            from manim import *
+            from manim_slides import Slide
+
+            class WithoutWaitBetweenLoopingSlidesExample(Slide):
+                def construct(self):
+                    self.wait_time_between_slides = 0.5
+                    self.wait_between_looping_slides = False
+                    dot = Dot(color=BLUE, radius=1)
+
+                    self.play(FadeIn(dot))
+                    self.next_slide(loop=True)
+
+                    self.play(Indicate(dot, scale_factor=2))
+
+                    self.next_slide()
+
+                    self.play(FadeOut(dot))
+
         """
         return self._wait_between_looping_slides
 

--- a/manim_slides/slide/base.py
+++ b/manim_slides/slide/base.py
@@ -57,6 +57,7 @@ class BaseSlide:
         self._start_animation = 0
         self._canvas: MutableMapping[str, Mobject] = {}
         self._wait_time_between_slides = 0.0
+        self._wait_between_looping_slides = True
         self._skip_animations = False
 
     @property
@@ -285,6 +286,27 @@ class BaseSlide:
     def wait_time_between_slides(self, wait_time: float) -> None:
         self._wait_time_between_slides = max(wait_time, 0.0)
 
+    @property
+    def wait_between_looping_slides(self) -> bool:
+        """
+        Return whether :attr:`wait_time_between_slides` should also apply
+        to slides that loop, i.e., slides created with
+        ``self.next_slide(loop=True)``.
+
+        By default, this value is set to :data:`True`, for backward
+        compatibility.
+
+        Setting this value to :data:`False` avoids the small pause added by
+        :attr:`wait_time_between_slides` right before a looping slide starts,
+        which can otherwise be visible as an unwanted stutter every time the
+        loop repeats.
+        """
+        return self._wait_between_looping_slides
+
+    @wait_between_looping_slides.setter
+    def wait_between_looping_slides(self, wait_between_looping_slides: bool) -> None:
+        self._wait_between_looping_slides = wait_between_looping_slides
+
     def play(self, *args: Any, **kwargs: Any) -> None:
         """Overload 'self.play' and increment animation count."""
         super().play(*args, **kwargs)  # type: ignore[misc]
@@ -475,7 +497,9 @@ class BaseSlide:
 
         """
         if self._current_animation > self._start_animation:
-            if self.wait_time_between_slides > 0.0:
+            if self.wait_time_between_slides > 0.0 and (
+                self.wait_between_looping_slides or not self._base_slide_config.loop
+            ):
                 self.wait(self.wait_time_between_slides)  # type: ignore[attr-defined]
 
             self._slides.append(

--- a/tests/test_base_slide.py
+++ b/tests/test_base_slide.py
@@ -86,6 +86,13 @@ class TestBaseSlide:
 
         assert base_slide.wait_time_between_slides == 0.0
 
+    def test_wait_between_looping_slides(self, base_slide: BaseSlide) -> None:
+        assert base_slide.wait_between_looping_slides
+
+        base_slide.wait_between_looping_slides = False
+
+        assert not base_slide.wait_between_looping_slides
+
     def test_skip_animations(self, base_slide: BaseSlide) -> None:
         assert not base_slide._skip_animations
 

--- a/tests/test_slide.py
+++ b/tests/test_slide.py
@@ -20,6 +20,7 @@ from manim import (
     Circle,
     Dot,
     FadeIn,
+    FadeOut,
     GrowFromCenter,
     Square,
     Text,
@@ -540,6 +541,26 @@ class TestSlide:
                 assert self._current_animation == 1
                 self.next_slide()
                 assert self._current_animation == 2  # self.wait = +1
+
+    def test_wait_between_looping_slides(self) -> None:
+        @assert_constructs
+        class _(CESlide):
+            def construct(self) -> None:
+                self._wait_time_between_slides = 1.0
+                self.wait_between_looping_slides = False
+                circle = Circle(color=BLUE)
+                self.play(GrowFromCenter(circle))
+                assert self._current_animation == 1
+                self.next_slide(loop=True)
+                assert (
+                    self._current_animation == 2
+                )  # self.wait = +1, slide is not a loop yet
+                self.play(FadeOut(circle))
+                assert self._current_animation == 3
+                self.next_slide()
+                assert (
+                    self._current_animation == 3
+                )  # no extra wait, closing slide loops
 
     def test_next_slide(self) -> None:
         @assert_constructs


### PR DESCRIPTION
Fixes #647.

`wait_time_between_slides` adds a `self.wait()` at the end of every slide so animations terminate cleanly before moving on. The problem is that this wait also gets added right before a slide created with `next_slide(loop=True)`, so every time the loop repeats, there's a small stutter from that pause.

This adds a `wait_between_looping_slides` property, defaulting to `True` so nothing changes for existing projects. Setting it to `False` skips the wait specifically for slides that loop.

Added tests in `tests/test_base_slide.py` (getter/setter) and `tests/test_slide.py` (checking the animation count with and without the wait, following the same pattern as the existing `test_wait_time_between_slides` test).

Ran `uv run pre-commit run --all-files` locally, all green. I wasn't able to run the full `pytest` suite on this machine because of an unrelated Cairo/architecture mismatch in my local Homebrew setup (manim's renderer fails to import), so I traced through the `next_slide` logic by hand and mirrored the existing test style closely; happy to fix anything CI turns up.