### PR TITLE
feat: add wait_between_looping_slides property

### DIFF
--- a/manim_slides/slide/base.py
+++ b/manim_slides/slide/base.py
@@ -314,6 +314,7 @@ class BaseSlide:
                     self.next_slide(loop=True)
 
                     self.play(FadeOut(circle))
+
         """
         return self._wait_between_looping_slides
 
@@ -514,8 +515,7 @@ class BaseSlide:
             # Apply wait time unless this is a looping slide and
             # wait_between_looping_slides is disabled
             should_wait = self.wait_time_between_slides > 0.0 and (
-                self.wait_between_looping_slides
-                or not self._base_slide_config.loop
+                self.wait_between_looping_slides or not self._base_slide_config.loop
             )
             if should_wait:
                 self.wait(self.wait_time_between_slides)  # type: ignore[attr-defined]

--- a/manim_slides/slide/base.py
+++ b/manim_slides/slide/base.py
@@ -57,6 +57,7 @@ class BaseSlide:
         self._start_animation = 0
         self._canvas: MutableMapping[str, Mobject] = {}
         self._wait_time_between_slides = 0.0
+        self._wait_between_looping_slides = True
         self._skip_animations = False
 
     @property
@@ -285,6 +286,41 @@ class BaseSlide:
     def wait_time_between_slides(self, wait_time: float) -> None:
         self._wait_time_between_slides = max(wait_time, 0.0)
 
+    @property
+    def wait_between_looping_slides(self) -> bool:
+        """
+        Return whether wait time is applied between looping slides.
+
+        By default, this value is set to True.
+
+        Setting this value to False will disable the use of
+        :attr:`wait_time_between_slides` for slides that have
+        ``loop=True``, preventing pauses when looping.
+
+        Examples
+        --------
+        .. manim-slides:: NoWaitLoopExample
+
+            from manim import *
+            from manim_slides import Slide
+
+            class NoWaitLoopExample(Slide):
+                def construct(self):
+                    self.wait_time_between_slides = 1.0
+                    self.wait_between_looping_slides = False
+
+                    circle = Circle(radius=2)
+                    self.play(Create(circle))
+                    self.next_slide(loop=True)
+
+                    self.play(FadeOut(circle))
+        """
+        return self._wait_between_looping_slides
+
+    @wait_between_looping_slides.setter
+    def wait_between_looping_slides(self, value: bool) -> None:
+        self._wait_between_looping_slides = value
+
     def play(self, *args: Any, **kwargs: Any) -> None:
         """Overload 'self.play' and increment animation count."""
         super().play(*args, **kwargs)  # type: ignore[misc]
@@ -475,7 +511,13 @@ class BaseSlide:
 
         """
         if self._current_animation > self._start_animation:
-            if self.wait_time_between_slides > 0.0:
+            # Apply wait time unless this is a looping slide and
+            # wait_between_looping_slides is disabled
+            should_wait = self.wait_time_between_slides > 0.0 and (
+                self.wait_between_looping_slides
+                or not self._base_slide_config.loop
+            )
+            if should_wait:
                 self.wait(self.wait_time_between_slides)  # type: ignore[attr-defined]
 
             self._slides.append(

--- a/tests/test_base_slide.py
+++ b/tests/test_base_slide.py
@@ -86,6 +86,13 @@ class TestBaseSlide:
 
         assert base_slide.wait_time_between_slides == 0.0
 
+    def test_wait_between_looping_slides(self, base_slide: BaseSlide) -> None:
+        assert base_slide.wait_between_looping_slides is True
+
+        base_slide.wait_between_looping_slides = False
+
+        assert base_slide.wait_between_looping_slides is False
+
     def test_skip_animations(self, base_slide: BaseSlide) -> None:
         assert not base_slide._skip_animations
 

--- a/tests/test_slide.py
+++ b/tests/test_slide.py
@@ -541,6 +541,23 @@ class TestSlide:
                 self.next_slide()
                 assert self._current_animation == 2  # self.wait = +1
 
+    def test_wait_between_looping_slides(self) -> None:
+        @assert_constructs
+        class _(CESlide):
+            def construct(self) -> None:
+                self._wait_time_between_slides = 1.0
+                self.wait_between_looping_slides = False
+                assert not self.wait_between_looping_slides
+                circle = Circle(color=BLUE)
+                self.play(GrowFromCenter(circle))
+                self.next_slide(loop=True)
+                # wait should NOT be added for looping slides
+                assert self._current_animation == 1
+                self.play(GrowFromCenter(circle))
+                self.next_slide()
+                # wait should be added for non-looping slides
+                assert self._current_animation == 2
+
     def test_next_slide(self) -> None:
         @assert_constructs
         class _(CESlide):


### PR DESCRIPTION
## Summary

Closes #647

Adds a new boolean property `wait_between_looping_slides` (default True) that controls whether `wait_time_between_slides` is applied to slides with `loop=True`.

When set to False, the wait time is skipped for looping slides, preventing pauses between loop iterations.

## Changes

- Added `wait_between_looping_slides` property to `BaseSlide`
- Updated `next_slide()` to check the flag before applying wait time
- Added tests for the new property

## Usage

```python
self.wait_time_between_slides = 1.0
self.wait_between_looping_slides = False

circle = Circle(radius=2)
self.play(Create(circle))
self.next_slide(loop=True)  # No wait time added
```

## Backward Compatibility

The new property defaults to True, so all existing behavior is preserved.