### PR TITLE
feat(present): add key binding for resetting time

### DIFF
--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -165,6 +165,10 @@ class Info(QWidget):  # type: ignore[misc]
 
         self.setLayout(main_layout)
 
+    def reset_elapsed_time(self) -> None:
+        self.start_time = datetime.now()
+        self.update_time()
+
     @Slot()
     def update_time(self) -> None:
         now = datetime.now()
@@ -667,5 +671,15 @@ class Player(QMainWindow):  # type: ignore[misc]
 
     def keyPressEvent(self, event: QKeyEvent) -> None:  # noqa: N802
         key = event.key()
+
+        # Ctrl+Shift+R resets the elapsed-time counter. The chord is deliberately
+        # awkward so it can't be triggered by accident mid-presentation.
+        if key == Qt.Key_R and event.modifiers() & Qt.ControlModifier and (
+            event.modifiers() & Qt.ShiftModifier
+        ):
+            self.info.reset_elapsed_time()
+            event.accept()
+            return
+        
         self.dispatch(key)
         event.accept()

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -674,12 +674,14 @@ class Player(QMainWindow):  # type: ignore[misc]
 
         # Ctrl+Shift+R resets the elapsed-time counter. The chord is deliberately
         # awkward so it can't be triggered by accident mid-presentation.
-        if key == Qt.Key_R and event.modifiers() & Qt.ControlModifier and (
-            event.modifiers() & Qt.ShiftModifier
+        if (
+            key == Qt.Key_R
+            and event.modifiers() & Qt.ControlModifier
+            and (event.modifiers() & Qt.ShiftModifier)
         ):
             self.info.reset_elapsed_time()
             event.accept()
             return
-        
+
         self.dispatch(key)
         event.accept()


### PR DESCRIPTION
Hello! I've been using `manin-slides` for my master's thesis defense and I needed to do some changes, so I'm contributing them back upstream if you think they might be useful. I'll open a few PRs with small changes that I think are reasonable, but feel free to change or close them if you don't think they quite fit. 

## Description

Add a keybind for resetting time. This is useful to be more accurate when tracking time elapsed if you have a target time. I put it at a slightly awkward bind to avoid resetting on accident. 

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.