### PR TITLE
feat(present): add clicker-compatible key binding

### DIFF
--- a/manim_slides/config.py
+++ b/manim_slides/config.py
@@ -89,16 +89,29 @@ class Key(BaseModel):  # type: ignore[misc]
 class Keys(BaseModel):  # type: ignore[misc]
     QUIT: Key = Field(default_factory=lambda: Key(ids=[key_id("Q")], name="QUIT"))
     PLAY_PAUSE: Key = Field(
-        default_factory=lambda: Key(ids=[key_id("Space")], name="PLAY / PAUSE")
+        # B is emitted by presentation clickers
+        default_factory=lambda: Key(
+            ids=[key_id("Space"), key_id("B")], name="PLAY / PAUSE"
+        )
     )
-    NEXT: Key = Field(default_factory=lambda: Key(ids=[key_id("Right")], name="NEXT"))
+    # PageUp / PageDown are emitted by presentation clickers
+    NEXT: Key = Field(
+        default_factory=lambda: Key(
+            ids=[key_id("Right"), key_id("PageDown")], name="NEXT"
+        )
+    )
     PREVIOUS: Key = Field(
-        default_factory=lambda: Key(ids=[key_id("Left")], name="PREVIOUS")
+        default_factory=lambda: Key(
+            ids=[key_id("Left"), key_id("PageUp")], name="PREVIOUS"
+        )
     )
     REVERSE: Key = Field(default_factory=lambda: Key(ids=[key_id("V")], name="REVERSE"))
     REPLAY: Key = Field(default_factory=lambda: Key(ids=[key_id("R")], name="REPLAY"))
     FULL_SCREEN: Key = Field(
-        default_factory=lambda: Key(ids=[key_id("F")], name="TOGGLE FULL SCREEN")
+        # P is emitted by presentation clickers
+        default_factory=lambda: Key(
+            ids=[key_id("F"), key_id("P")], name="TOGGLE FULL SCREEN"
+        )
     )
     HIDE_MOUSE: Key = Field(
         default_factory=lambda: Key(ids=[key_id("H")], name="HIDE / SHOW MOUSE")


### PR DESCRIPTION
Part of #652

## Description

I bought a generic office clicker and it triggers pageup/down keys. This change makes it work out of the box with these clickers. I am unsure, however, if these binds are universal across clickers.

I guess the more robust way to handle this is to allow to change keybinds, but I think it's reasonable to include these by default.

I also included some auxiliary buttons that seem common among these clickers. 

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.

