### PR TITLE
feat(present): avoid infinite looping in next slide preview

### DIFF
--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -136,7 +136,7 @@ class Info(QWidget):  # type: ignore[misc]
         self.next_media_player.setLoops(-1)
 
         perview_layout.addWidget(self.next_video_widget, stretch=1)
-        
+
         self.next_image_label = QLabel()
         self.next_image_label.setAlignment(Qt.AlignCenter)
         self.next_image_label.setScaledContents(False)

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -129,12 +129,14 @@ class Info(QWidget):  # type: ignore[misc]
         )
         self.next_video_widget = QVideoWidget()
         self.next_video_widget.setAspectRatioMode(aspect_ratio_mode)
+        self.next_video_widget.setMinimumSize(320, 180)
+        self.next_video_sink = self.next_video_widget.videoSink()
         self.next_media_player = QMediaPlayer()
         self.next_media_player.setVideoOutput(self.next_video_widget)
         self.next_media_player.setLoops(-1)
 
-        perview_layout.addWidget(self.next_video_widget)
-
+        perview_layout.addWidget(self.next_video_widget, stretch=1)
+        
         self.next_image_label = QLabel()
         self.next_image_label.setAlignment(Qt.AlignCenter)
         self.next_image_label.setScaledContents(False)
@@ -250,6 +252,7 @@ class Player(QMainWindow):  # type: ignore[misc]
         self.setWindowIcon(self.icon)
 
         self.frame = QVideoFrame()
+        self.next_frame = QVideoFrame()
 
         self.audio_output = QAudioOutput()
         self.video_widget = QVideoWidget()
@@ -285,6 +288,7 @@ class Player(QMainWindow):  # type: ignore[misc]
         self.info.close_event.connect(self.closeEvent)
         self.info.key_press_event.connect(self.keyPressEvent)
         self.video_sink.videoFrameChanged.connect(self.frame_changed)
+        self.info.next_video_sink.videoFrameChanged.connect(self.next_frame_changed)
         self.hide_info_window = hide_info_window
 
         # Connecting key callbacks
@@ -661,6 +665,14 @@ class Player(QMainWindow):  # type: ignore[misc]
             self.video_sink.setVideoFrame(self.frame)  # Reuse previous frame
 
         self.info.video_sink.setVideoFrame(self.frame)
+
+    def next_frame_changed(self, frame: QVideoFrame) -> None:
+        # Same workaround as :meth:`frame_changed`, applied to the "next slide"
+        # preview, so it freezes on its last frame instead of flashing black.
+        if frame.isValid():
+            self.next_frame = frame
+        else:
+            self.info.next_video_sink.setVideoFrame(self.next_frame)
 
     def closeEvent(self, event: QCloseEvent) -> None:  # noqa: N802
         self.close()


### PR DESCRIPTION
Part of #652 

## Description

I'm not sure if you want to implement this change, but I felt it was distracting to see the next animation on repeat in the next slide preview. Especially for short animations/transitions. This changes it so that the last frame is frozen. 

I suppose that it would be even better if this could be configured, although maybe it's too small and it might pollute the config flags. Not a big change either way, up to your discretion :)

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.

Thank you for this project!
