### PR TITLE
fix(convert/html): fix flickering on slide change with --one-file

### DIFF
--- a/docs/source/_static/template.html
+++ b/docs/source/_static/template.html
@@ -311,33 +311,42 @@
         });
       }
 
-      function fixBase64VideoBackground(event) {
-        // Analyze all slides backgrounds
-        for (const slide of Reveal.getBackgroundsElement().querySelectorAll('.slide-background')) {
-          // Get the slide video and its sources for each background
-          const video = slide.querySelector('video');
-          if (video) {
-            setVideoBase64(video);
-          } else {
-            // Listen to the creation of the video element
-            const observer = new MutationObserver((mutationsList) => {
-              for (const mutation of mutationsList) {
-                if (mutation.type === 'childList') {
-                  for (const addedNode of mutation.addedNodes) {
-                    if (addedNode.tagName === 'VIDEO') {
-                      setVideoBase64(addedNode);
-                      observer.disconnect(); // Stop observing once the video is handled
-                    }
+      const _observedBgSlides = new WeakSet();
+
+      function fixSlideBackground(bg) {
+        if (_observedBgSlides.has(bg)) return;
+        _observedBgSlides.add(bg);
+        const video = bg.querySelector('video');
+        if (video) {
+          setVideoBase64(video);
+        } else {
+          const observer = new MutationObserver((mutationsList) => {
+            for (const mutation of mutationsList) {
+              if (mutation.type === 'childList') {
+                for (const addedNode of mutation.addedNodes) {
+                  if (addedNode.tagName === 'VIDEO') {
+                    setVideoBase64(addedNode);
+                    observer.disconnect();
+                    return;
                   }
                 }
               }
-            });
-            observer.observe(slide, { childList: true, subtree: true });
-          }
+            }
+          });
+          observer.observe(bg, { childList: true, subtree: true });
         }
       }
-      // Setup base64 videos
+
+      function fixBase64VideoBackground() {
+        const backgroundsEl = Reveal.getBackgroundsElement();
+        if (!backgroundsEl) return;
+        for (const bg of backgroundsEl.querySelectorAll('.slide-background')) {
+          fixSlideBackground(bg);
+        }
+      }
+
       Reveal.on( 'ready', fixBase64VideoBackground );
+      Reveal.on( 'slidechanged', fixBase64VideoBackground );
       {% endif %}
     </script>
 

--- a/manim_slides/templates/firebase_sync.html
+++ b/manim_slides/templates/firebase_sync.html
@@ -502,7 +502,7 @@
         });
       }
 
-      var _observedBgSlides = new WeakSet();
+      const _observedBgSlides = new WeakSet();
 
       function fixSlideBackground(bg) {
         if (_observedBgSlides.has(bg)) return;

--- a/manim_slides/templates/firebase_sync.html
+++ b/manim_slides/templates/firebase_sync.html
@@ -502,33 +502,42 @@
         });
       }
 
-      function fixBase64VideoBackground(event) {
-        // Analyze all slides backgrounds
-        for (const slide of Reveal.getBackgroundsElement().querySelectorAll('.slide-background')) {
-          // Get the slide video and its sources for each background
-          const video = slide.querySelector('video');
-          if (video) {
-            setVideoBase64(video);
-          } else {
-            // Listen to the creation of the video element
-            const observer = new MutationObserver((mutationsList) => {
-              for (const mutation of mutationsList) {
-                if (mutation.type === 'childList') {
-                  for (const addedNode of mutation.addedNodes) {
-                    if (addedNode.tagName === 'VIDEO') {
-                      setVideoBase64(addedNode);
-                      observer.disconnect(); // Stop observing once the video is handled
-                    }
+      var _observedBgSlides = new WeakSet();
+
+      function fixSlideBackground(bg) {
+        if (_observedBgSlides.has(bg)) return;
+        _observedBgSlides.add(bg);
+        const video = bg.querySelector('video');
+        if (video) {
+          setVideoBase64(video);
+        } else {
+          const observer = new MutationObserver((mutationsList) => {
+            for (const mutation of mutationsList) {
+              if (mutation.type === 'childList') {
+                for (const addedNode of mutation.addedNodes) {
+                  if (addedNode.tagName === 'VIDEO') {
+                    setVideoBase64(addedNode);
+                    observer.disconnect();
+                    return;
                   }
                 }
               }
-            });
-            observer.observe(slide, { childList: true, subtree: true });
-          }
+            }
+          });
+          observer.observe(bg, { childList: true, subtree: true });
         }
       }
-      // Setup base64 videos
+
+      function fixBase64VideoBackground() {
+        const backgroundsEl = Reveal.getBackgroundsElement();
+        if (!backgroundsEl) return;
+        for (const bg of backgroundsEl.querySelectorAll('.slide-background')) {
+          fixSlideBackground(bg);
+        }
+      }
+
       Reveal.on( 'ready', fixBase64VideoBackground );
+      Reveal.on( 'slidechanged', fixBase64VideoBackground );
       {% endif %}
     </script>
     {% if env['READTHEDOCS'] %}

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -313,33 +313,42 @@
         });
       }
 
-      function fixBase64VideoBackground(event) {
-        // Analyze all slides backgrounds
-        for (const slide of Reveal.getBackgroundsElement().querySelectorAll('.slide-background')) {
-          // Get the slide video and its sources for each background
-          const video = slide.querySelector('video');
-          if (video) {
-            setVideoBase64(video);
-          } else {
-            // Listen to the creation of the video element
-            const observer = new MutationObserver((mutationsList) => {
-              for (const mutation of mutationsList) {
-                if (mutation.type === 'childList') {
-                  for (const addedNode of mutation.addedNodes) {
-                    if (addedNode.tagName === 'VIDEO') {
-                      setVideoBase64(addedNode);
-                      observer.disconnect(); // Stop observing once the video is handled
-                    }
+      var _observedBgSlides = new WeakSet();
+
+      function fixSlideBackground(bg) {
+        if (_observedBgSlides.has(bg)) return;
+        _observedBgSlides.add(bg);
+        const video = bg.querySelector('video');
+        if (video) {
+          setVideoBase64(video);
+        } else {
+          const observer = new MutationObserver((mutationsList) => {
+            for (const mutation of mutationsList) {
+              if (mutation.type === 'childList') {
+                for (const addedNode of mutation.addedNodes) {
+                  if (addedNode.tagName === 'VIDEO') {
+                    setVideoBase64(addedNode);
+                    observer.disconnect();
+                    return;
                   }
                 }
               }
-            });
-            observer.observe(slide, { childList: true, subtree: true });
-          }
+            }
+          });
+          observer.observe(bg, { childList: true, subtree: true });
         }
       }
-      // Setup base64 videos
+
+      function fixBase64VideoBackground() {
+        const backgroundsEl = Reveal.getBackgroundsElement();
+        if (!backgroundsEl) return;
+        for (const bg of backgroundsEl.querySelectorAll('.slide-background')) {
+          fixSlideBackground(bg);
+        }
+      }
+
       Reveal.on( 'ready', fixBase64VideoBackground );
+      Reveal.on( 'slidechanged', fixBase64VideoBackground );
       {% endif %}
     </script>
     {% if env['READTHEDOCS'] %}

--- a/manim_slides/templates/revealjs.html
+++ b/manim_slides/templates/revealjs.html
@@ -313,7 +313,7 @@
         });
       }
 
-      var _observedBgSlides = new WeakSet();
+      const _observedBgSlides = new WeakSet();
 
       function fixSlideBackground(bg) {
         if (_observedBgSlides.has(bg)) return;


### PR DESCRIPTION
Closes #426

When using `--one-file` mode, base64-encoded video data URIs are split into multiple `<source>` elements by RevealJS. The existing `fixBase64VideoBackground` only ran on the `ready` event, so dynamically created video elements (when navigating to slides outside the initial `viewDistance`) were never fixed, causing a visible blank frame flicker on slide transitions.

This adds a `slidechanged` handler that re-runs the fix on every slide transition. A `WeakSet` tracks already-processed backgrounds to avoid duplicate MutationObserver setup.