### PR TITLE
fix(convert): quote enum-typed HTML config values set via -c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated static type checking from `mypy` to [`ty`](https://github.com/astral-sh/ty).
   [#636](https://github.com/jeertmans/manim-slides/pull/636)
 
-### fix
+### Fix
 - Fixed enum-typed HTML config values set via `-c` not being quoted in the output,
   producing a blank presentation, and restored validation of those values.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed enum-typed HTML config values set via `-c` not being quoted in the output,
   producing a blank presentation, and restored validation of those values.
-[@lapotist](https://github.com/lapotist) [#664](https://github.com/jeertmans/manim-slides/pull/664)
+  [@lapotist](https://github.com/lapotist) [#664](https://github.com/jeertmans/manim-slides/pull/664)
 
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed enum-typed HTML config values set via `-c` not being quoted in the output,
   producing a blank presentation, and restored validation of those values.
-
-  [@lapotist](https://github.com/lapotist) [#664](https://github.com/jeertmans/manim-slides/pull/664)
+[@lapotist](https://github.com/lapotist) [#664](https://github.com/jeertmans/manim-slides/pull/664)
 
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated static type checking from `mypy` to [`ty`](https://github.com/astral-sh/ty).
   [#636](https://github.com/jeertmans/manim-slides/pull/636)
 
+### fix
+- Fixed enum-typed HTML config values set via `-c` not being quoted in the output,
+  producing a blank presentation, and restored validation of those values.
+
+  [@lapotist](https://github.com/lapotist) [#664](https://github.com/jeertmans/manim-slides/pull/664)
+
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated static type checking from `mypy` to [`ty`](https://github.com/astral-sh/ty).
   [#636](https://github.com/jeertmans/manim-slides/pull/636)
 
-### Fix
+### Fixed
+
 - Fixed enum-typed HTML config values set via `-c` not being quoted in the output,
   producing a blank presentation, and restored validation of those values.
 

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -189,7 +189,9 @@ class Str(str):
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
-        return core_schema.str_schema()
+        return core_schema.no_info_after_validator_function(
+            cls, core_schema.str_schema()
+        )
 
     def __str__(self) -> str:
         """Ensure that the string is correctly quoted."""

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 from bs4 import BeautifulSoup
 from click import Context, Parameter
+from pydantic import BaseModel
 
 from manim_slides.config import PresentationConfig
 from manim_slides.convert import (
@@ -151,6 +152,42 @@ def test_quoted_enum(enum_type: type[Enum]) -> None:
 
         expected = "'" + enum.value + "'"
         got = str(enum)
+
+        assert expected == got
+
+
+@pytest.mark.parametrize(
+    ("enum_type",),
+    [
+        (ControlsLayout,),
+        (ControlsBackArrows,),
+        (SlideNumber,),
+        (ShowSlideNumber,),
+        (KeyboardCondition,),
+        (NavigationMode,),
+        (AutoPlayMedia,),
+        (PreloadIframes,),
+        (AutoAnimateMatcher,),
+        (AutoAnimateEasing,),
+        (AutoSlideMethod,),
+        (Transition,),
+        (TransitionSpeed,),
+        (BackgroundSize,),
+        (BackgroundTransition,),
+        (Display,),
+    ],
+)
+def test_quoted_enum_survives_pydantic_validation(enum_type: type[Enum]) -> None:
+    class Model(BaseModel):
+        value: enum_type  # type: ignore[valid-type]
+
+    for enum in enum_type:
+        if enum in ["true", "false", "null"]:
+            continue
+
+        model = Model(value=enum.value)
+        expected = "'" + enum.value + "'"
+        got = str(model.value)
 
         assert expected == got
 


### PR DESCRIPTION
## Description

`Str` (the mixin behind `Transition`, `BackgroundTransition`, `ControlsLayout`,
and 13 other enum config types used by the `html` converter) quotes itself
correctly via `__str__`, but only when Python already holds a real instance
of the enum. `Str.__get_pydantic_core_schema__` returns a bare
`core_schema.str_schema()`, so any value that arrives through pydantic
validation — including every value set via `-c key=value` — is kept as a
plain `str` instead of being rebuilt into the enum type. `Str.__str__` never
runs on that plain string, so the value reaches `templates/revealjs.html`
unquoted.

Concretely:

    manim-slides convert MyScene out.html -c transition=fade

emits `transition: fade,` into the page's inline JS instead of
`transition: 'fade',`. `fade` is then read as an undefined variable
reference, throwing at slide-init time and aborting the whole init script —
the exported presentation is a blank page, with no error surfaced anywhere
in the CLI output.

This isn't limited to `transition`: all 16 `(Str, StrEnum)` config types
(`controls_layout`, `slide_number`, `keyboard_condition`,
`navigation_mode`, `auto_play_media`, `background_size`, etc.) share the
same schema method and are equally affected when set via `-c`.

**Fix:** validate as a string, then reconstruct the proper type from it:

    core_schema.no_info_after_validator_function(cls, core_schema.str_schema())

This also restores validation that was silently missing — before this
change, `-c transition=anything` was accepted with no error; now invalid
values correctly raise `ValidationError`.

### Why the existing tests didn't catch this

`test_quoted_enum` (test_convert.py) only checks `str()` on the enum
members directly (`for enum in enum_type: ... str(enum)`), which never
exercises pydantic validation — the actual codepath a `-c` value travels
through. I added `test_quoted_enum_survives_pydantic_validation` next to it,
which builds a minimal model, validates each enum's value through pydantic
(mirroring what `-c key=value` does), and asserts the quoting survives.
Confirmed this test fails on current `main` (12/16 parametrized cases) and
passes with the fix.

## Check List

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [ ] If I modified already existing code, I updated the documentation accordingly; <!-- no user-facing docs reference this internal schema method -->
- [x] The title of my pull request is a short description of the requested changes.

## Note to reviewers

- One-line fix in `manim_slides/convert.py`; the rest of the diff is the new regression test.
- `ruff check`, `ruff format`, and `ty check` all pass on the changed files (verified against unmodified `main` that the 2 `ty` diagnostics elsewhere in the file are pre-existing, unrelated to this change).
- Full `tests/test_convert.py` + `tests/test_config.py`: 88/88 pass.
- Happy to also open this as an issue first if you'd rather track it separately before reviewing the PR — let me know your preference.

**AI disclosure:** investigated and drafted with AI assistance (Claude Code); root cause, fix, and tests were independently verified before submission.
