### PR TITLE
fix(present): player looping erroneously when reversing multiple slides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix presenter looping when reversing multiple slides [#665](https://github.com/jeertmans/manim-slides/pull/665)
+- Fixed presenter looping when reversing multiple slides.
+  [#665](https://github.com/jeertmans/manim-slides/pull/665)
 
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed presenter looping when reversing multiple slides.
-  [#665](https://github.com/jeertmans/manim-slides/pull/665)
+  [@wuerfelfreak](https://github.com/wuerfelfreak) [#665](https://github.com/jeertmans/manim-slides/pull/665)
 
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated static type checking from `mypy` to [`ty`](https://github.com/astral-sh/ty).
   [#636](https://github.com/jeertmans/manim-slides/pull/636)
 
+### Fixed
+
+- Fix presenter looping when reversing multiple slides [#665](https://github.com/jeertmans/manim-slides/pull/665)
+
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)
 

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -469,7 +469,10 @@ class Player(QMainWindow):
 
     def load_current_slide(self) -> None:
         slide_config = self.current_slide_config
-        self.current_file = slide_config.file
+        if self.playing_reversed_slide:
+            self.current_file = slide_config.rev_file
+        else:
+            self.current_file = slide_config.file
 
         if slide_config.loop:
             self.media_player.setLoops(-1)
@@ -512,8 +515,7 @@ class Player(QMainWindow):
 
     def load_reversed_slide(self) -> None:
         self.playing_reversed_slide = True
-        self.current_file = self.current_slide_config.rev_file
-        self.load_current_media()
+        self.load_current_slide()
 
     """
     Key callbacks and slots


### PR DESCRIPTION
## Description

Currently when the player is on a slide that loops and then reverse is pressed multiple times so that the player lands on a non-looping slide, the player plays the video in a loop even though it should not. 

The reason is that `load_reversed_slide` calls `load_current_media` directly without the code block in `load_current_slide` that adjusts the looping behavior running beforehand. 
I changed it so that `load_reversed_slide` also calls `load_current_slide` and moved the functionality of setting the path to the reversed version to `load_current_slide`. 

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [ ] If I created new functions / methods, I documented them and add type hints;
- [ ] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.