### PR TITLE
fix(present): not reversing to previous scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [@lapotist](https://github.com/lapotist) [#664](https://github.com/jeertmans/manim-slides/pull/664)
 - Fixed presenter looping when reversing multiple slides.
   [@wuerfelfreak](https://github.com/wuerfelfreak) [#665](https://github.com/jeertmans/manim-slides/pull/665)
+- Fixed presenter not reversing to previous scene.
+  [@wuerfelfreak](https://github.com/wuerfelfreak) [#671](https://github.com/jeertmans/manim-slides/pull/671)
 
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)

--- a/manim_slides/present/player.py
+++ b/manim_slides/present/player.py
@@ -482,8 +482,6 @@ class Player(QMainWindow):
         self.load_current_media()
 
     def load_previous_slide(self) -> None:
-        self.playing_reversed_slide = False
-
         if self.current_slide_index > 0:
             self.current_slide_index -= 1
         elif self.current_presentation_index > 0:
@@ -511,10 +509,6 @@ class Player(QMainWindow):
             logger.info("No more slide to play.")
             return
 
-        self.load_current_slide()
-
-    def load_reversed_slide(self) -> None:
-        self.playing_reversed_slide = True
         self.load_current_slide()
 
     """
@@ -598,15 +592,13 @@ class Player(QMainWindow):
 
     @Slot()
     def previous(self) -> None:
+        self.playing_reversed_slide = False
         self.load_previous_slide()
 
     @Slot()
     def reverse(self) -> None:
-        if self.playing_reversed_slide and self.current_slide_index >= 1:
-            self.current_slide_index -= 1
-
-        self.load_reversed_slide()
-        self.preview_next_slide()
+        self.playing_reversed_slide = True
+        self.load_previous_slide()
 
     @Slot()
     def replay(self) -> None:


### PR DESCRIPTION
## Fixes Issue

When present is called with multiple scenes (e.g. ` manim-slides Scene1 Scene2`)  and is advanced to the second scene it is not possible to get back to the first scene by pressing the reverse button. As soon as the first slide of the second slide is reached by pressing the reverse button, further presses only restart the animation. Pressing the previous_slide button however does work to get back to the first scene. 

This is because `reverse` checks if `current_slide_index >= 1` but does not consider that `current_presentation_index` might be `> 0`.
```python
@Slot()
def reverse(self) -> None:
    if self.playing_reversed_slide and self.current_slide_index >= 1:
        self.current_slide_index -= 1

    self.load_reversed_slide()
    self.preview_next_slide()
``` 

## Description

`load_previous_slide` already correctly implements the boundary check. Therefore I reused the implementation of `load_previous_slide`. To do that I moved the assignment of self.playing_reversed_slide to `reverse` and `previous` and then called `load_previous_slide` from both, eliminating `load_reversed_slide` in the process.

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [ ] If I created new functions / methods, I documented them and add type hints;
- [ ] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.