### PR TITLE
fix(lib): use spawn-based pool in reverse_video_file to avoid fork deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [@lapotist](https://github.com/lapotist) [#664](https://github.com/jeertmans/manim-slides/pull/664)
 - Fixed presenter looping when reversing multiple slides.
   [@wuerfelfreak](https://github.com/wuerfelfreak) [#665](https://github.com/jeertmans/manim-slides/pull/665)
+- Fixed intermittent deadlocks when reversing large videos by creating the
+  worker pool with the `spawn` start method instead of `fork`.
+  [@Agi-Asi](https://github.com/Agi-Asi) [#672](https://github.com/jeertmans/manim-slides/pull/672)
 
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)

--- a/manim_slides/utils.py
+++ b/manim_slides/utils.py
@@ -1,10 +1,10 @@
 import hashlib
+import multiprocessing as mp
 import os
 import shutil
 import tempfile
 from collections.abc import Iterator
 from itertools import pairwise
-from multiprocessing import Pool
 from pathlib import Path
 from typing import Any, TypeVar, cast
 
@@ -220,7 +220,19 @@ def reverse_video_file(
                 src_file.with_stem("rev_" + src_file.stem) for src_file in src_files
             ]
 
-            with Pool(num_processes, maxtasksperchild=1) as pool:
+            # Worker processes are created with the 'spawn' start method:
+            # the default 'fork' on Linux duplicates this process while the
+            # parent holds PyAV/FFmpeg (and possibly tqdm) locks from the
+            # still-open input container above — a forked child can then
+            # inherit a lock in a locked state with no owner to release it,
+            # and the pool deadlocks on its queue semaphore. Observed as
+            # renders hanging in 'Reversing large file by cutting it in
+            # segments' (#562) and as a multiprocessing semaphore deadlock
+            # (#569). 'spawn' starts clean interpreters, which cannot
+            # inherit held locks, and matches the default on macOS/Windows.
+            with mp.get_context("spawn").Pool(
+                num_processes, maxtasksperchild=1
+            ) as pool:
                 for _ in tqdm(
                     pool.imap_unordered(
                         reverse_video_file_in_one_chunk,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from manim_slides.utils import merge_basenames
+import av
+
+from manim_slides.utils import merge_basenames, reverse_video_file
 
 
 def test_merge_basenames(paths: list[Path]) -> None:
@@ -20,3 +22,19 @@ def test_merge_basenames_same_with_different_parent_directories(
     p4 = d2 / "d/e/f/two.txt"
 
     assert merge_basenames([p1, p2]).name == merge_basenames([p3, p4]).name
+
+
+def test_reverse_video_file_segmented(video_file: Path, tmp_path: Path) -> None:
+    # Regression test for #562 / #569: the segmented path runs a
+    # multiprocessing pool while the parent still holds an open PyAV input
+    # container. With the previous fork-based pool this could deadlock
+    # (forked children inherit held FFmpeg/tqdm locks); with the spawn-based
+    # pool it must complete and produce a decodable, non-empty video.
+    dest = tmp_path / "reversed.mp4"
+
+    reverse_video_file(video_file, dest, max_segment_duration=0.5)
+
+    assert dest.exists()
+    with av.open(str(dest)) as container:
+        frames = sum(1 for _ in container.decode(video=0))
+    assert frames > 0


### PR DESCRIPTION
<!-- Thanks for contributing to Manim Slides! -->

## Description

Segmented video reversal runs a `multiprocessing.Pool` while the parent process still holds an **open PyAV input container** (the `with av.open(src)` wrapping the whole body of `reverse_video_file`). On Linux the default `fork` start method duplicates the parent mid-flight: a forked child can inherit an FFmpeg/PyAV (or tqdm) lock in a locked state with no owner left to release it, and the pool then deadlocks on its own queue semaphore.

This matches the reported failures exactly:

- renders hanging in `Reversing large file by cutting it in segments` (#562)
- a worker stuck in `multiprocessing/queues.py get() → semlock.__enter__`, only surfaced after Ctrl-C as a `KeyboardInterrupt` stack trace (#569 — the trace in that issue is *precisely* a worker blocked on the inherited queue rlock)

Both are probabilistic — the fork has to race a held lock — which is why small projects never hit it and larger ones (more segments → more workers → more forks) hit it once every 10–20 renders, as reported.

**Fix:** create the pool from an explicit `spawn` context. Freshly spawned interpreters cannot inherit held locks, and this matches the default start method on macOS and Windows — Linux was the odd one out. `reverse_video_file_in_one_chunk` is a module-level function taking picklable `Path` arguments, so it is already spawn-compatible; a few interpreter startups are noise next to the video re-encoding the workers perform.

## Testing

- New regression test drives the segmented path (segment duration forced below the test asset's length, so the pool actually runs) and asserts a decodable, non-empty output.
- `pytest tests/test_utils.py` — 3 passed.
- `ruff check` / `ruff format --check` clean on the touched files.

Fixes #562
Fixes #569

<!-- If this is your first contribution and you'd like to be added to the contributors list, feel free to say so. -->
