### PR TITLE
fix(lib): concat list entries broke on relative paths and quotes in paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [@lapotist](https://github.com/lapotist) [#664](https://github.com/jeertmans/manim-slides/pull/664)
 - Fixed presenter looping when reversing multiple slides.
   [@wuerfelfreak](https://github.com/wuerfelfreak) [#665](https://github.com/jeertmans/manim-slides/pull/665)
+- Fixed `concatenate_video_files` failing on relative input paths and on paths
+  containing single quotes, by writing absolute, properly escaped entries to
+  the concat list file.
+  [@Agi-Asi](https://github.com/Agi-Asi) [#673](https://github.com/jeertmans/manim-slides/pull/673)
 
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [@lapotist](https://github.com/lapotist) [#664](https://github.com/jeertmans/manim-slides/pull/664)
 - Fixed presenter looping when reversing multiple slides.
   [@wuerfelfreak](https://github.com/wuerfelfreak) [#665](https://github.com/jeertmans/manim-slides/pull/665)
-- Fixed `concatenate_video_files` failing on relative input paths and on paths
-  containing single quotes, by writing absolute, properly escaped entries to
-  the concat list file.
+- Fixed `concatenate_video_files` failing on relative input paths and on paths containing single quotes, by writing absolute, properly escaped entries to the concat list file.
   [@Agi-Asi](https://github.com/Agi-Asi) [#673](https://github.com/jeertmans/manim-slides/pull/673)
 
 (v5.6.0)=

--- a/manim_slides/utils.py
+++ b/manim_slides/utils.py
@@ -42,7 +42,7 @@ def _concat_list_entry(file: Path) -> str:
     escaped shell-style ('\''), which is the quoting ffmpeg's
     av_get_token() understands.
     """
-    escaped = str(file.resolve()).replace("'", "'\\''")
+    escaped = file.resolve().as_posix().replace("'", "'\\''")
     return f"file '{escaped}'\n"
 
 

--- a/manim_slides/utils.py
+++ b/manim_slides/utils.py
@@ -31,6 +31,21 @@ def add_stream_from_template_legacy(
     return add_stream(template=template)
 
 
+def _concat_list_entry(file: Path) -> str:
+    r"""
+    Format one entry of an ffmpeg concat demuxer list file.
+
+    The concat demuxer resolves *relative* paths against the directory of
+    the list file — which lives in the system temp folder, not the current
+    working directory — so every relative input silently became a dangling
+    reference. Write absolute paths instead. Quotes inside the path are
+    escaped shell-style ('\''), which is the quoting ffmpeg's
+    av_get_token() understands.
+    """
+    escaped = str(file.resolve()).replace("'", "'\\''")
+    return f"file '{escaped}'\n"
+
+
 def concatenate_video_files(files: list[Path], dest: Path) -> None:
     """Concatenate multiple video files into one."""
     if len(files) == 1:
@@ -54,7 +69,7 @@ def concatenate_video_files(files: list[Path], dest: Path) -> None:
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".txt", delete=False, encoding="utf-8"
     ) as f:
-        f.writelines(f"file '{file}'\n" for file in _filter(files))
+        f.writelines(_concat_list_entry(file) for file in _filter(files))
         tmp_file = f.name
 
     with (

--- a/manim_slides/utils.py
+++ b/manim_slides/utils.py
@@ -31,21 +31,6 @@ def add_stream_from_template_legacy(
     return add_stream(template=template)
 
 
-def _concat_list_entry(file: Path) -> str:
-    r"""
-    Format one entry of an ffmpeg concat demuxer list file.
-
-    The concat demuxer resolves *relative* paths against the directory of
-    the list file — which lives in the system temp folder, not the current
-    working directory — so every relative input silently became a dangling
-    reference. Write absolute paths instead. Quotes inside the path are
-    escaped shell-style ('\''), which is the quoting ffmpeg's
-    av_get_token() understands.
-    """
-    escaped = file.resolve().as_posix().replace("'", "'\\''")
-    return f"file '{escaped}'\n"
-
-
 def concatenate_video_files(files: list[Path], dest: Path) -> None:
     """Concatenate multiple video files into one."""
     if len(files) == 1:
@@ -69,7 +54,12 @@ def concatenate_video_files(files: list[Path], dest: Path) -> None:
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".txt", delete=False, encoding="utf-8"
     ) as f:
-        f.writelines(_concat_list_entry(file) for file in _filter(files))
+        # Write absolute paths and escape single quotes ('\'') so that ffmpeg's
+        # concat demuxer parses every entry correctly, see #673.
+        f.writelines(
+            "file '{}'\n".format(file.resolve().as_posix().replace("'", "'\\''"))
+            for file in _filter(files)
+        )
         tmp_file = f.name
 
     with (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,10 @@
+import shutil
 from pathlib import Path
 
-from manim_slides.utils import merge_basenames
+import av
+import pytest
+
+from manim_slides.utils import concatenate_video_files, merge_basenames
 
 
 def test_merge_basenames(paths: list[Path]) -> None:
@@ -20,3 +24,38 @@ def test_merge_basenames_same_with_different_parent_directories(
     p4 = d2 / "d/e/f/two.txt"
 
     assert merge_basenames([p1, p2]).name == merge_basenames([p3, p4]).name
+
+
+def _assert_decodable(dest: Path) -> None:
+    assert dest.exists()
+    with av.open(str(dest)) as container:
+        assert sum(1 for _ in container.decode(video=0)) > 0
+
+
+def test_concatenate_video_files_relative_paths(
+    video_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The concat list file lives in the system temp folder, and the concat
+    # demuxer resolves relative entries against *that* folder — so relative
+    # input paths used to fail with FileNotFoundError.
+    monkeypatch.chdir(video_file.parent)
+    relative = Path(video_file.name)
+    dest = tmp_path / "out.mp4"
+
+    concatenate_video_files([relative, relative], dest)
+
+    _assert_decodable(dest)
+
+
+def test_concatenate_video_files_quoted_path(video_file: Path, tmp_path: Path) -> None:
+    # A single quote in a path used to terminate the quoted list entry early,
+    # making the entry unparseable for the concat demuxer.
+    quoted_dir = tmp_path / "John's slides"
+    quoted_dir.mkdir()
+    src = quoted_dir / video_file.name
+    shutil.copy(video_file, src)
+    dest = tmp_path / "out.mp4"
+
+    concatenate_video_files([src, src], dest)
+
+    _assert_decodable(dest)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,7 +26,7 @@ def test_merge_basenames_same_with_different_parent_directories(
     assert merge_basenames([p1, p2]).name == merge_basenames([p3, p4]).name
 
 
-def _assert_decodable(dest: Path) -> None:
+def assert_has_decodable_video_stream(dest: Path) -> None:
     assert dest.exists()
     with av.open(str(dest)) as container:
         assert sum(1 for _ in container.decode(video=0)) > 0
@@ -44,7 +44,7 @@ def test_concatenate_video_files_relative_paths(
 
     concatenate_video_files([relative, relative], dest)
 
-    _assert_decodable(dest)
+    assert_has_decodable_video_stream(dest)
 
 
 def test_concatenate_video_files_quoted_path(video_file: Path, tmp_path: Path) -> None:
@@ -58,4 +58,4 @@ def test_concatenate_video_files_quoted_path(video_file: Path, tmp_path: Path) -
 
     concatenate_video_files([src, src], dest)
 
-    _assert_decodable(dest)
+    assert_has_decodable_video_stream(dest)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,7 +49,7 @@ def test_concatenate_video_files_relative_paths(
 
 def test_concatenate_video_files_quoted_path(video_file: Path, tmp_path: Path) -> None:
     # A single quote in a path used to terminate the quoted list entry early,
-    # making the entry unparseable for the concat demuxer.
+    # making the entry unparsable for the concat demuxer.
     quoted_dir = tmp_path / "John's slides"
     quoted_dir.mkdir()
     src = quoted_dir / video_file.name


### PR DESCRIPTION
<!-- Thanks for contributing to Manim Slides! -->

## Description

`concatenate_video_files` writes an ffmpeg concat demuxer list file into the **system temp directory**, with entries written verbatim as `file '<path>'`. Two failure modes fall out of that:

1. **Relative input paths silently break.** The concat demuxer resolves relative entries against the directory of the *list file* (the temp folder), not the caller's working directory — so every relative segment path became a dangling reference and `av.open` failed with `FileNotFoundError` on files that exist. Reproduced locally by calling `concatenate_video_files([Path('tests/data/video.mp4'), ...])` from the repo root.

2. **Quotes in paths make entries unparseable.** A single quote anywhere in a component (`John's slides/…`) terminates the quoted entry early. Any user whose project lives under such a directory gets a confusing parse/`FileNotFoundError` failure from deep inside PyAV.

**Fix**, in one place (`_concat_list_entry`): entries are written as **absolute (resolved) paths**, with single quotes escaped shell-style (`'\''`) — the quoting ffmpeg's `av_get_token()` understands.

Today's internal callers happen to always pass absolute paths, which is why the pipeline works — but `concatenate_video_files` is part of the importable API surface, and both failure modes produce errors that look exactly like the "file vanished mid-render" class of reports (e.g. the `Errno 22 Invalid argument` family in #540 is being debugged around this same function). Hardening the list-file writing removes two entire failure modes from the suspect list.

## Testing

- Two new regression tests: relative CWD-dependent input (via `monkeypatch.chdir`), and a path containing a single quote — both assert a decodable output. Both fail on `main` and pass with this change.
- `pytest tests/test_utils.py` — 4 passed.
- `ruff check` / `ruff format --check` clean (the helper moved to module level to stay under the complexity limit).

<!-- If this is your first contribution and you'd like to be added to the contributors list, feel free to say so. -->
