### PR TITLE
fix(utils): add timeout and sequential fallback for segmented video reversal

### DIFF
--- a/manim_slides/utils.py
+++ b/manim_slides/utils.py
@@ -5,6 +5,7 @@ import tempfile
 from collections.abc import Iterator
 from itertools import pairwise
 from multiprocessing import Pool
+from multiprocessing import TimeoutError as MultiprocessingTimeoutError
 from pathlib import Path
 from typing import Any, TypeVar, cast
 
@@ -225,17 +226,39 @@ def reverse_video_file(
                 src_file.with_stem("rev_" + src_file.stem) for src_file in src_files
             ]
 
-            with Pool(num_processes, maxtasksperchild=1) as pool:
-                for _ in tqdm(
-                    pool.imap_unordered(
-                        reverse_video_file_in_one_chunk,
-                        zip(src_files, rev_files, strict=True),
-                    ),
-                    desc="Reversing large file by cutting it in segments",
+            # Timeout per segment in seconds (generous: 10 min per segment).
+            segment_timeout = 600
+
+            try:
+                with Pool(num_processes, maxtasksperchild=1) as pool:
+                    results = []
+                    async_results = [
+                        pool.apply_async(reverse_video_file_in_one_chunk, (args,))
+                        for args in zip(src_files, rev_files, strict=True)
+                    ]
+
+                    for ar in tqdm(
+                        async_results,
+                        desc="Reversing large file by cutting it in segments",
+                        total=len(async_results),
+                        unit=" files",
+                        **tqdm_kwargs,
+                    ):
+                        ar.get(timeout=segment_timeout)
+                        results.append(True)
+
+            except (MultiprocessingTimeoutError, OSError) as exc:
+                logger.warning(
+                    f"Parallel segment reversal failed ({type(exc).__name__}: {exc}), "
+                    "falling back to sequential reversal."
+                )
+                for src_file, rev_file in tqdm(
+                    zip(src_files, rev_files, strict=True),
+                    desc="Reversing segments sequentially (fallback)",
                     total=len(src_files),
                     unit=" files",
                     **tqdm_kwargs,
                 ):
-                    pass  # We just consume the iterator
+                    reverse_video_file_in_one_chunk((src_file, rev_file))
 
             concatenate_video_files(rev_files[::-1], dest)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,14 @@ import shutil
 from pathlib import Path
 
 import av
+import numpy as np
 import pytest
 
-from manim_slides.utils import concatenate_video_files, merge_basenames
+from manim_slides.utils import (
+    concatenate_video_files,
+    merge_basenames,
+    reverse_video_file,
+)
 
 
 def test_merge_basenames(paths: list[Path]) -> None:
@@ -57,5 +62,49 @@ def test_concatenate_video_files_quoted_path(video_file: Path, tmp_path: Path) -
     dest = tmp_path / "out.mp4"
 
     concatenate_video_files([src, src], dest)
+
+    assert_has_decodable_video_stream(dest)
+
+
+def _make_long_video(dest: Path, duration: float = 10.0, fps: int = 24) -> None:
+    """Write a synthetic video of the given duration (solid-color frames)."""
+    width, height = 320, 240
+    with av.open(str(dest), mode="w") as container:
+        stream = container.add_stream("libx264", rate=fps)
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = "yuv420p"
+        total_frames = int(duration * fps)
+        for i in range(total_frames):
+            frame = av.VideoFrame.from_ndarray(
+                np.full((height, width, 3), (i % 256), dtype=np.uint8),
+                format="rgb24",
+            )
+            for packet in stream.encode(frame):
+                container.mux(packet)
+        for packet in stream.encode():
+            container.mux(packet)
+
+
+def test_reverse_video_file_segmented(video_file: Path, tmp_path: Path) -> None:
+    """Segmented reversal (long video) completes without deadlock."""
+    long_src = tmp_path / "long.mp4"
+    _make_long_video(long_src, duration=10.0)
+
+    dest = tmp_path / "reversed.mp4"
+    reverse_video_file(long_src, dest, max_segment_duration=2.0, num_processes=2)
+
+    assert_has_decodable_video_stream(dest)
+
+
+def test_reverse_video_file_segmented_sequential_fallback(
+    video_file: Path, tmp_path: Path
+) -> None:
+    """When max_segment_duration is None, reversal uses a single chunk (no pool)."""
+    long_src = tmp_path / "long.mp4"
+    _make_long_video(long_src, duration=10.0)
+
+    dest = tmp_path / "reversed.mp4"
+    reverse_video_file(long_src, dest, max_segment_duration=None)
 
     assert_has_decodable_video_stream(dest)


### PR DESCRIPTION
## What Problem This Solves

On some platforms and configurations, the multiprocessing pool in `reverse_video_file` can deadlock when reversing large videos that are automatically split into segments. The `Pool.imap_unordered` call with `maxtasksperchild=1` hangs indefinitely if a worker process crashes or encounters an error (issue #562).

## Why This Change Was Made

The existing code uses `Pool.imap_unordered` which provides no timeout mechanism — if a worker dies, the main process blocks forever. This forces users to work around the bug by setting `max_duration_before_split_reverse = None`, disabling segmented reversal entirely.

## What Changed

- Replaced `Pool.imap_unordered` with `Pool.apply_async` + per-segment timeout (600s)
- Added `try/except` for `MultiprocessingTimeoutError` and `OSError`
- On failure, falls back to sequential reversal so rendering never stalls
- Added 2 regression tests:
  - `test_reverse_video_file_segmented` — exercises the parallel segmented path with a 10s video
  - `test_reverse_video_file_segmented_sequential_fallback` — exercises the single-chunk path

## How Tested

- All 6 tests in `tests/test_utils.py` pass:
  - 4 existing tests (unchanged)
  - 2 new tests for segmented and single-chunk reversal
- `ruff check` and `ruff format` pass on both modified files

## Behavior Trade-offs

- The 600s per-segment timeout is generous (10 minutes) to avoid false positives on slow systems
- The sequential fallback is slower than parallel but guarantees completion
- The warning log message includes the failure reason for debugging

Fixes #562
