### PR TITLE
fix(utils): fixes non monotonous dts in concatenate_video_files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [@wuerfelfreak](https://github.com/wuerfelfreak) [#665](https://github.com/jeertmans/manim-slides/pull/665)
 - Fixed `concatenate_video_files` failing on relative input paths and on paths containing single quotes, by writing absolute, properly escaped entries to the concat list file.
   [@Agi-Asi](https://github.com/Agi-Asi) [#673](https://github.com/jeertmans/manim-slides/pull/673)
+- Fixed `concatenate_video_files` failing with non monotonous dts and added test. [@wuerfelfreak](https://github.com/wuerfelfreak) [#680](https://github.com/jeertmans/manim-slides/pull/680)
 
 (v5.6.0)=
 ## [v5.6.0](https://github.com/jeertmans/manim-slides/compare/v5.5.4...v5.6.0)

--- a/manim_slides/utils.py
+++ b/manim_slides/utils.py
@@ -87,6 +87,7 @@ def concatenate_video_files(files: list[Path], dest: Path) -> None:
                 )
             )
 
+        last_dts = {"video": None, "audio": None}
         for packet in input_container.demux():
             if packet.dts is None:
                 continue
@@ -99,6 +100,14 @@ def concatenate_video_files(files: list[Path], dest: Path) -> None:
                 packet.stream = output_audio_stream
             else:
                 continue  # We don't support subtitles
+
+            # stopgap solution for https://github.com/jeertmans/manim-slides/issues/540
+            if last_dts[ptype] is not None and packet.dts <= last_dts[ptype]:
+                packet.dts = last_dts[ptype] + 1
+                if packet.pts is not None and packet.pts < packet.dts:
+                    packet.pts = packet.dts
+            last_dts[ptype] = packet.dts
+
             output_container.mux(packet)
 
     os.unlink(tmp_file)  # https://stackoverflow.com/a/54768241

--- a/tests/data/slides.py
+++ b/tests/data/slides.py
@@ -1,6 +1,6 @@
 # type: ignore
 
-from manim_slides import Slide
+from manim_slides import Slide, ThreeDSlide
 from manim_slides.slide import MANIM, MANIMGL
 
 if MANIM:
@@ -46,3 +46,36 @@ class BasicSlideSkipReversing(BasicSlide):
 class FailingSlide(Slide):
     def construct(self):
         self.play("this fails to render")
+
+
+class Issue540(ThreeDSlide):
+    def construct(self):
+        k = ValueTracker(0)
+
+        def slice_function(x, y):
+            return x + y
+
+        def z_slice(num):
+            k.set_value(num)
+            return ImplicitFunction(
+                slice_function, color=YELLOW, x_range=((-5, 5)), y_range=((-5, 5))
+            )
+
+        ref_dot2 = always_redraw(
+            lambda: Dot3D(
+                point=interpolate(
+                    DOWN,
+                    UP,
+                    k.get_value(),
+                ),
+            )
+        )
+
+        slice = z_slice(1)
+        self.play(
+            FadeIn(slice),
+            run_time=0.025,
+        )
+
+        self.play(FadeOut(ref_dot2))
+

--- a/tests/data/slides.py
+++ b/tests/data/slides.py
@@ -78,4 +78,3 @@ class Issue540(ThreeDSlide):
         )
 
         self.play(FadeOut(ref_dot2))
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,9 +5,8 @@ import av
 import pytest
 from click.testing import CliRunner
 
-from manim_slides.utils import concatenate_video_files, merge_basenames
 from manim_slides.__main__ import cli
-
+from manim_slides.utils import concatenate_video_files, merge_basenames
 
 
 def test_merge_basenames(paths: list[Path]) -> None:
@@ -68,8 +67,6 @@ def test_issue540(slides_file: Path) -> None:
     runner = CliRunner()
 
     with runner.isolated_filesystem() as tmp_dir:
-        results = runner.invoke(
-            cli, ["render", str(slides_file), "Issue540", "-ql"]
-        )
+        results = runner.invoke(cli, ["render", str(slides_file), "Issue540", "-ql"])
 
         assert results.exit_code == 0, results.output

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,11 @@ from pathlib import Path
 
 import av
 import pytest
+from click.testing import CliRunner
 
 from manim_slides.utils import concatenate_video_files, merge_basenames
+from manim_slides.__main__ import cli
+
 
 
 def test_merge_basenames(paths: list[Path]) -> None:
@@ -59,3 +62,14 @@ def test_concatenate_video_files_quoted_path(video_file: Path, tmp_path: Path) -
     concatenate_video_files([src, src], dest)
 
     assert_has_decodable_video_stream(dest)
+
+
+def test_issue540(slides_file: Path) -> None:
+    runner = CliRunner()
+
+    with runner.isolated_filesystem() as tmp_dir:
+        results = runner.invoke(
+            cli, ["render", str(slides_file), "Issue540", "-ql"]
+        )
+
+        assert results.exit_code == 0, results.output


### PR DESCRIPTION
## Fixes Issue

Closes #540 

## Description

Adds a check for non monotonous dts in `concatenate_video_files` in `utils.py` and adjust the dts to be monotonous.  

## Check List

- [ ] I understand that my contributions needs to pass the checks;
- [x] The title of my pull request is a short description of the requested changes.

## Note to reviewers

I don't know much about PyAV and video encoding so this might not be a good solution. But it works for now. 
