### PR TITLE
feat(convert): add portable HTML player export

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,11 @@ jobs:
         enable-cache: true
 
     - name: Install Chromium and system dependencies
-      run: uv run --frozen --group browser-tests playwright install --with-deps chromium
+      run: >-
+        uv run --frozen --no-default-groups --group browser-tests
+        playwright install --with-deps chromium
 
     - name: Run first-party HTML player browser tests
-      run: uv run --frozen --group browser-tests pytest tests/test_html_player_browser.py -q
+      run: >-
+        uv run --frozen --no-default-groups --group browser-tests
+        pytest tests/test_html_player_browser.py -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,3 +117,22 @@ jobs:
         use-quiet-mode: yes
         use-verbose-mode: yes
         config-file: .mdlc.json
+
+  html-player-browser:
+    runs-on: ubuntu-latest
+    env:
+      MANIM_SLIDES_BROWSER_TESTS: 1
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Install Chromium and system dependencies
+      run: uv run --frozen --group browser-tests playwright install --with-deps chromium
+
+    - name: Run first-party HTML player browser tests
+      run: uv run --frozen --group browser-tests pytest tests/test_html_player_browser.py -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an offline first-party HTML player export with asset-backed and portable
+  single-file packaging, reverse playback, mobile controls, and accessible
+  presentation affordances.
 - Added `firebase_sync.html` template to enable realtime slide syncing via
   Firebase Realtime Database, including a usage guide in the templates
   directory. [@liuktc](https://github.com/liuktc) [#638](https://github.com/jeertmans/manim-slides/pull/638)

--- a/bandit.yml
+++ b/bandit.yml
@@ -1,3 +1,3 @@
 assert_used:
   skips:
-  - "*test_*.py"
+  - '*test_*.py'

--- a/bandit.yml
+++ b/bandit.yml
@@ -1,0 +1,3 @@
+assert_used:
+  skips:
+  - "*test_*.py"

--- a/docs/source/features_table.md
+++ b/docs/source/features_table.md
@@ -17,7 +17,7 @@ The following summarizes the different presentation features Manim Slides offers
 | Requires internet access | No | Depends[^1] | No | No | No |
 | Auto. play slides | Yes | Yes | Yes | Yes | N/A |
 | Loops support | Yes | Yes | Yes | Yes | N/A |
-| Fully customizable | No | Yes (`--use-template` option) | Scoped CSS overrides | No | No |
+| Fully customizable | No | Yes (`--use-template`) | CSS overrides | No | No |
 | Other dependencies | None | A modern web browser | A modern web browser | PowerPoint or LibreOffice Impress[^2] | None |
 | Works cross-platforms | Yes | Yes | Yes[^4] | Partly[^2][^3] | Yes |
 :::

--- a/docs/source/features_table.md
+++ b/docs/source/features_table.md
@@ -6,20 +6,20 @@ The following summarizes the different presentation features Manim Slides offers
 :widths: auto
 :align: center
 
-| Feature / Constraint | [`present`](reference/cli.md) | [`convert --to=html`](reference/cli.md) | [`convert --to=pptx`](reference/cli.md) | [`convert --to=pdf`](reference/cli.md)
-| :--- | :---: | :---: | :---: | :---: |
-| Basic navigation through slides | Yes | Yes | Yes | Yes (static image) |
-| Replay slide | Yes | No | No | N/A |
-| Pause animation | Yes | Yes | No | N/A |
-| Play slide in reverse | Yes | No | No | N/A |
-| Slide count | Yes | Yes (optional) | Yes (optional) | N/A |
-| Needs Python with Manim Slides installed | Yes | No | No | No
-| Requires internet access | No | Depends[^1] | No | No |
-| Auto. play slides | Yes | Yes | Yes | N/A |
-| Loops support | Yes | Yes | Yes | N/A |
-| Fully customizable | No | Yes (`--use-template` option) | No | No |
-| Other dependencies | None | A modern web browser | PowerPoint or LibreOffice Impress[^2] | None |
-| Works cross-platforms | Yes | Yes | Partly[^2][^3] | Yes |
+| Feature / Constraint | [`present`](reference/cli.md) | [`convert --to=html`](reference/cli.md) | [`convert --to=html-player`](reference/cli.md) | [`convert --to=pptx`](reference/cli.md) | [`convert --to=pdf`](reference/cli.md)
+| :--- | :---: | :---: | :---: | :---: | :---: |
+| Basic navigation through slides | Yes | Yes | Yes | Yes | Yes (static image) |
+| Replay slide | Yes | No | Yes | No | N/A |
+| Pause animation | Yes | Yes | Yes | No | N/A |
+| Play slide in reverse | Yes | No | Yes | No | N/A |
+| Slide count | Yes | Yes (optional) | Yes | Yes (optional) | N/A |
+| Needs Python with Manim Slides installed | Yes | No | No | No | No
+| Requires internet access | No | Depends[^1] | No | No | No |
+| Auto. play slides | Yes | Yes | Yes | Yes | N/A |
+| Loops support | Yes | Yes | Yes | Yes | N/A |
+| Fully customizable | No | Yes (`--use-template` option) | Scoped CSS overrides | No | No |
+| Other dependencies | None | A modern web browser | A modern web browser | PowerPoint or LibreOffice Impress[^2] | None |
+| Works cross-platforms | Yes | Yes | Yes[^4] | Partly[^2][^3] | Yes |
 :::
 
 [^1]: By default, HTML assets are loaded from the internet, but they can be
@@ -29,3 +29,4 @@ The following summarizes the different presentation features Manim Slides offers
   [file an issue on GitHub](https://github.com/jeertmans/manim-slides/issues/new/choose).
 [^3]: PowerPoint online does not seem to support automatic playing of videos,
   so you need LibreOffice Impress on Linux platforms.
+[^4]: Media codec support depends on the browser and operating system.

--- a/docs/source/reference/cli.md
+++ b/docs/source/reference/cli.md
@@ -19,8 +19,10 @@ Each converter has its own configuration options, which are listed below.
 ::::
 
 ::::{dropdown} First-party HTML player
+
 ```{program-output} manim-slides convert --to=html-player --show-config
 ```
+
 ::::
 
 ::::{dropdown} Zip

--- a/docs/source/reference/cli.md
+++ b/docs/source/reference/cli.md
@@ -18,6 +18,11 @@ Each converter has its own configuration options, which are listed below.
 ```
 ::::
 
+::::{dropdown} First-party HTML player
+```{program-output} manim-slides convert --to=html-player --show-config
+```
+::::
+
 ::::{dropdown} Zip
 :::{note}
 The Zip converter inherits from the HTML converter.

--- a/docs/source/reference/html.md
+++ b/docs/source/reference/html.md
@@ -74,8 +74,9 @@ most one navigation command.
 Browsers may reject playback until the user interacts with the page, especially
 when externally supplied media contains audio. The player then shows a clear
 play button and remains paused instead of claiming to be playing. With
-`prefers-reduced-motion: reduce`, animations settle on their end frame without
-autoplay; navigation, notes, and direct jumps remain available.
+`prefers-reduced-motion: reduce`, animations remain paused on their starting
+frame until the viewer chooses **Play animation** or explicitly replays them;
+navigation, notes, and direct jumps remain available.
 
 ### Browser, accessibility, and embedding notes
 

--- a/docs/source/reference/html.md
+++ b/docs/source/reference/html.md
@@ -1,8 +1,13 @@
 # HTML Presentations
 
-Manim Slides allows you to convert presentations into one HTML file, with
-[RevealJS](https://revealjs.com/). This file can then be opened with any modern
-web browser, allowing for a nice portability of your presentations.
+Manim Slides provides two HTML exporters:
+
+- `--to=html` is the existing [RevealJS](https://revealjs.com/) exporter. It
+  remains the default for an `.html` destination and supports RevealJS templates
+  and configuration.
+- `--to=html-player` uses the dependency-free Manim Slides player. It supports
+  generated reverse media, replay, touch input, and completely self-contained
+  offline output.
 
 As with every command with Manim Slides, converting slides' fragments into one
 HTML file (and its assets) can be done in one command:
@@ -11,9 +16,91 @@ HTML file (and its assets) can be done in one command:
 manim-slides convert [SCENES]... DEST
 ```
 
-where `DEST` is the `.html` destination file.
+where `DEST` is the `.html` destination file. Automatic format detection chooses
+RevealJS; select the first-party player explicitly:
 
-## Configuring the Template
+```bash
+manim-slides convert BasicExample presentation.html --to=html-player
+```
+
+## First-party HTML player
+
+The default player output is one HTML file plus a `presentation_assets`
+directory. The directory contains the local runtime and collision-safe copies of
+every forward and reverse media asset. Keep it beside the HTML file when moving
+or publishing the presentation. The output makes no CDN or telemetry requests.
+
+For a single portable file, add `--one-file`:
+
+```bash
+manim-slides convert BasicExample presentation.html --to=html-player --one-file
+```
+
+The portable file contains the manifest, player, styles, and media. It can be
+opened directly by double-clicking it (`file://`); no local server or internet
+connection is needed. Media is decoded lazily into Blob URLs, with a bounded
+working set. Portable files are approximately one third larger than their raw
+binary media because of Base64 encoding, and the current and nearby decoded
+assets require additional browser memory. Prefer asset-backed output for large
+decks or web hosting.
+
+### Playback and controls
+
+The player loads the replacement media and its target frame before displaying
+it. Backward navigation plays the generated reverse clip. When reversing a
+partly played forward clip, equal-duration media starts at the corresponding
+reverse time. If durations differ by more than 15%, the deterministic fallback
+plays the reverse clip from its beginning.
+
+Keyboard and presentation-remote controls are:
+
+| Input | Action |
+| :--- | :--- |
+| Space, Right, Page Down | Advance |
+| Left, Page Up | Go backward |
+| R | Replay the current forward animation |
+| P | Pause or resume at the configured playback rate |
+| N | Toggle safely rendered notes |
+| O | Toggle the compact overview; selecting a slide jumps to its held end frame |
+| F | Toggle fullscreen when the browser supports it |
+| ? | Show help |
+| Escape | Close overlays or leave fullscreen |
+
+A primary click or tap on the presentation advances. A horizontal swipe moves
+forward or backward. An upward swipe enters a following vertical slide, and a
+downward swipe leaves the current vertical slide. Each gesture dispatches at
+most one navigation command.
+
+Browsers may reject playback until the user interacts with the page, especially
+when externally supplied media contains audio. The player then shows a clear
+play button and remains paused instead of claiming to be playing. With
+`prefers-reduced-motion: reduce`, animations settle on their end frame without
+autoplay; navigation, notes, and direct jumps remain available.
+
+### Browser, accessibility, and embedding notes
+
+The player targets current desktop and mobile browsers with Blob URLs,
+`playsinline`, and standard HTML media support. Chromium is the required tested
+baseline. Actual codec support is browser- and operating-system-dependent; an
+unsupported or missing asset produces a slide- and role-specific error with
+retry and navigation controls.
+
+Controls are semantic buttons with visible keyboard focus and 44 CSS-pixel touch
+targets. Viewport sizing uses dynamic viewport units and safe-area insets. The
+player's CSS and input listeners are scoped to its root. In an embedded host,
+keyboard events are handled only while the player or one of its controls has
+focus, and pointer handling does not originate outside the player.
+
+The generated CSS class names and DOM structure are implementation details, not
+a compatibility API. For durable custom layout, place the generated file in a
+responsive `iframe`, or override only the outer `.manim-slides-player` size in a
+host integration and test it against the Manim Slides versions you support.
+
+Image slides use their static image for both logical directions. `loop`,
+`auto_next`, forward and reverse playback rates, notes, direction, multiple
+scenes, resolution, and background color come from the existing slide metadata.
+
+## Configuring the RevealJS template
 
 Many configuration options are available through the `-c<option>=<value>` syntax.
 Most, if not all, RevealJS options should be available by default. If that is
@@ -27,7 +114,7 @@ You can print the list of available options with:
 manim-slides convert --show-config
 ```
 
-## Using a Custom Template
+## Using a Custom RevealJS template
 
 The default template used for HTML conversion can be found on
 [GitHub](https://github.com/jeertmans/manim-slides/blob/main/manim_slides/templates/revealjs.html)

--- a/docs/source/reference/html.md
+++ b/docs/source/reference/html.md
@@ -56,27 +56,47 @@ Keyboard and presentation-remote controls are:
 
 | Input | Action |
 | :--- | :--- |
-| Space, Right, Page Down | Advance |
-| Left, Page Up | Go backward |
+| Space, Right, Page Down | Finish the current forward animation; press again to advance |
+| Left, Page Up | Finish active reverse playback or go backward |
 | R | Replay the current forward animation |
 | P | Pause or resume at the configured playback rate |
 | N | Toggle safely rendered notes |
 | O | Toggle the compact overview; selecting a slide jumps to its held end frame |
-| F | Toggle fullscreen when the browser supports it |
+| F | Enter or exit Present mode |
 | ? | Show help |
-| Escape | Close overlays or leave fullscreen |
+| Escape | Close an overlay or exit Present mode |
 
-A primary click or tap on the presentation advances. A horizontal swipe moves
-forward or backward. An upward swipe enters a following vertical slide, and a
-downward swipe leaves the current vertical slide. Each gesture dispatches at
-most one navigation command.
+A primary click or tap, a leftward swipe, and the **Next** button use the same
+two-step forward behavior as Space: the first input finishes an animation that
+is still playing, and the next advances. A rightward swipe goes backward. An
+upward swipe enters a following vertical slide, and a downward swipe leaves the
+current vertical slide. Repeating Back while reverse playback is active finishes
+that transition deterministically. Each gesture dispatches at most one command.
+
+The **Present** button (or F) enters a clean presentation mode that hides the
+controls, slide position, and progress bar while keeping explicitly requested
+overlays available. The player requests browser fullscreen from the same user
+gesture. If fullscreen is unavailable or denied, the clean viewport-filling mode
+still works. Leaving browser fullscreen also leaves Present mode, and Escape
+restores the ordinary viewer chrome. F is deliberately the single command for
+both behaviors, avoiding separate fullscreen and presentation states.
+
+F5 is not assigned: Chromium and other browsers reserve it for reloading the
+current page, so the player cannot handle it consistently without risking lost
+presentation state. Chrome documents F5 as a reload shortcut in its
+[keyboard shortcut reference](https://support.google.com/chrome/answer/157179).
 
 Browsers may reject playback until the user interacts with the page, especially
 when externally supplied media contains audio. The player then shows a clear
-play button and remains paused instead of claiming to be playing. With
-`prefers-reduced-motion: reduce`, animations remain paused on their starting
-frame until the viewer chooses **Play animation** or explicitly replays them;
-navigation, notes, and direct jumps remain available.
+play button and remains paused instead of claiming to be playing. Without a
+reduced-motion preference, the first slide and each newly entered forward slide
+start automatically, subject to that browser policy. With
+`prefers-reduced-motion: reduce`, the first animation remains paused on its
+starting frame until the viewer chooses **Play animation**, **Replay**, or
+**Present**. That affirmative choice enables forward and reverse autoplay for
+the lifetime of that player instance, without changing the operating-system
+preference or writing persistent storage. Reloading the document resets the
+choice. Navigation, notes, and direct jumps remain available before opt-in.
 
 ### Browser, accessibility, and embedding notes
 

--- a/docs/source/reference/html.md
+++ b/docs/source/reference/html.md
@@ -56,12 +56,12 @@ Keyboard and presentation-remote controls are:
 
 | Input | Action |
 | :--- | :--- |
-| Space, Right, Page Down | Finish the current forward animation; press again to advance |
+| Space, Right, Page Down | Finish animation; press again to advance |
 | Left, Page Up | Finish active reverse playback or go backward |
 | R | Replay the current forward animation |
 | P | Pause or resume at the configured playback rate |
 | N | Toggle safely rendered notes |
-| O | Toggle the compact overview; selecting a slide jumps to its held end frame |
+| O | Toggle overview; selecting a slide jumps to its held end frame |
 | F | Enter or exit Present mode |
 | ? | Show help |
 | Escape | Close an overlay or exit Present mode |

--- a/docs/source/reference/sharing.md
+++ b/docs/source/reference/sharing.md
@@ -78,6 +78,11 @@ or directly proposing a
 A major advantage of HTML files is that they can be opened cross-platform,
 granted one has a modern web browser (which is pretty standard).
 
+See [HTML Presentations](html.md) for the choice between the default RevealJS
+export and the first-party `--to=html-player` export. The first-party player is
+offline in both asset-backed and `--one-file` modes and supports reverse
+navigation and mobile input.
+
 ### Sharing HTML and animation files
 
 First, you need to create the HTML file and its assets directory.
@@ -137,10 +142,12 @@ and it there to preserve the original aspect ratio (16:9).
 
 ### Sharing ONE HTML file
 
-If you set the `--one-file` flag, all animations will be data URI encoded,
-making the HTML a self-contained presentation file that can be shared
-on its own. If you also set the `--offline` flag, the JS and CSS files will
-be included in the HTML file as well.
+For the first-party player, `--to=html-player --one-file` embeds the local
+runtime and all media in one file that can be opened directly from `file://`.
+No `--offline` flag is needed.
+
+For the RevealJS exporter, `--one-file` embeds animations as data URIs. Add
+`--offline` to download and embed RevealJS CSS and JavaScript as well.
 
 ### Over the internet
 

--- a/manim_slides/convert.py
+++ b/manim_slides/convert.py
@@ -173,6 +173,7 @@ class Converter(BaseModel):
         """Return the appropriate converter from a string name."""
         return {
             "html": RevealJS,
+            "html-player": HtmlPlayer,
             "pdf": PDF,
             "pptx": PowerPoint,
             "zip": HtmlZip,
@@ -741,6 +742,45 @@ class HtmlZip(RevealJS):
             shutil.make_archive(str(dest.with_suffix("")), "zip", directory_name)
 
 
+class HtmlPlayer(Converter):
+    """First-party, dependency-free HTML presentation player options."""
+
+    template: None = Field(
+        None,
+        description="RevealJS templates are not supported by this exporter.",
+    )
+    one_file: bool = Field(
+        False,
+        description="Embed the player and all media in one portable HTML file.",
+    )
+    background_size: BackgroundSize = Field(
+        BackgroundSize.contain,
+        description="Fit media inside the player with 'contain' or 'cover'.",
+    )
+    title: str = Field("Manim Slides", description="Presentation title.")
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+
+    def open(self, file: Path) -> None:
+        webbrowser.open(file.absolute().as_uri())
+
+    def convert_to(self, dest: Path) -> None:
+        """Write the first-party HTML presentation to DEST."""
+        from .html_player import build_html_player
+
+        result = build_html_player(
+            self.presentation_configs,
+            dest,
+            self.assets_dir,
+            self.one_file,
+            self.title,
+            self.background_size,
+        )
+        logger.info(
+            f"Created {result.mode} HTML player at {dest} "
+            f"({result.output_size} bytes, {result.asset_count} media assets)."
+        )
+
+
 class FrameIndex(str, Enum):
     first = "first"
     last = "last"
@@ -1005,7 +1045,10 @@ def show_template_option(function: Callable[..., Any]) -> Callable[..., Any]:
 @click.argument("dest", type=click.Path(dir_okay=False, path_type=Path))
 @click.option(
     "--to",
-    type=click.Choice(["auto", "html", "pdf", "pptx", "zip"], case_sensitive=False),
+    type=click.Choice(
+        ["auto", "html", "html-player", "pdf", "pptx", "zip"],
+        case_sensitive=False,
+    ),
     metavar="FORMAT",
     default="auto",
     show_default=True,
@@ -1089,7 +1132,7 @@ def convert(
 
         if (
             one_file
-            and issubclass(cls, (RevealJS, HtmlZip))
+            and issubclass(cls, (RevealJS, HtmlZip, HtmlPlayer))
             and "one_file" not in config_options
         ):
             config_options["one_file"] = "true"
@@ -1115,6 +1158,9 @@ def convert(
             and "offline" not in config_options
         ):
             config_options["offline"] = "true"
+
+        if offline and issubclass(cls, HtmlPlayer):
+            logger.info("The first-party HTML player is already fully offline.")
 
         converter = cls(
             presentation_configs=presentation_configs,

--- a/manim_slides/html_player/__init__.py
+++ b/manim_slides/html_player/__init__.py
@@ -1,0 +1,5 @@
+"""First-party HTML player conversion and asset packaging."""
+
+from .converter import build_html_player
+
+__all__ = ["build_html_player"]

--- a/manim_slides/html_player/converter.py
+++ b/manim_slides/html_player/converter.py
@@ -1,0 +1,285 @@
+import base64
+import hashlib
+import html
+import json
+import mimetypes
+import os
+import shutil
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any, TextIO
+from urllib.parse import quote
+
+import av
+from av.error import FFmpegError
+from PIL import Image
+
+from ..config import PresentationConfig, SlideType
+
+
+@dataclass(frozen=True)
+class PlayerAsset:
+    id: str
+    source: Path
+    mime_type: str
+    kind: str
+    filename: str
+
+
+@dataclass(frozen=True)
+class PlayerBuildResult:
+    mode: str
+    asset_count: int
+    output_size: int
+
+
+def _resource_text(name: str) -> str:
+    return (
+        resources.files("manim_slides.html_player")
+        .joinpath(name)
+        .read_text(encoding="utf-8")
+    )
+
+
+def _safe_json(value: object) -> str:
+    """Serialize inert JSON without allowing an input to close its script tag."""
+    return (
+        json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        .replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+
+
+def _color_css(value: object) -> str:
+    return str(value)
+
+
+def _validate_media(path: Path, kind: str, slide_id: str, role: str) -> None:
+    try:
+        if kind == "image":
+            with Image.open(path) as image:
+                image.verify()
+        else:
+            with av.open(str(path)) as container:
+                if not container.streams.video:
+                    raise ValueError("it contains no video stream")
+                next(container.decode(video=0))
+    except (OSError, StopIteration, ValueError, FFmpegError) as error:
+        raise ValueError(
+            f"Slide '{slide_id}' has an unreadable {role} {kind} asset "
+            f"'{path}': {error}"
+        ) from error
+
+
+def _asset_for(
+    path: Path,
+    kind: str,
+    slide_id: str,
+    role: str,
+    assets_by_key: dict[tuple[str, str], PlayerAsset],
+) -> PlayerAsset:
+    mime_type = mimetypes.guess_type(path.name)[0]
+    expected_prefix = f"{kind}/"
+    if mime_type is None or not mime_type.startswith(expected_prefix):
+        raise ValueError(
+            f"Slide '{slide_id}' has unsupported {role} asset '{path}'; "
+            f"expected a recognized {kind} MIME type."
+        )
+
+    _validate_media(path, kind, slide_id, role)
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    hexdigest = digest.hexdigest()
+    key = (hexdigest, mime_type)
+    if key in assets_by_key:
+        return assets_by_key[key]
+
+    suffix = path.suffix.lower()
+    asset = PlayerAsset(
+        id=f"asset-{hexdigest[:16]}",
+        source=path,
+        mime_type=mime_type,
+        kind=kind,
+        filename=f"media-{hexdigest[:16]}{suffix}",
+    )
+    assets_by_key[key] = asset
+    return asset
+
+
+def _asset_reference(asset: PlayerAsset, one_file: bool) -> dict[str, str]:
+    reference = {
+        "id": asset.id,
+        "kind": asset.kind,
+        "mimeType": asset.mime_type,
+        "storage": "inline" if one_file else "file",
+    }
+    if not one_file:
+        reference["url"] = quote(asset.filename, safe="")
+    return reference
+
+
+def _plan(
+    presentation_configs: list[PresentationConfig],
+    title: str,
+    background_size: str,
+    one_file: bool,
+) -> tuple[dict[str, Any], list[PlayerAsset]]:
+    assets_by_key: dict[tuple[str, str], PlayerAsset] = {}
+    slides: list[dict[str, object]] = []
+    presentations: list[dict[str, object]] = []
+
+    for scene_index, presentation in enumerate(presentation_configs):
+        start = len(slides)
+        for slide_index, slide in enumerate(presentation.slides):
+            slide_id = f"scene-{scene_index + 1}-slide-{slide_index + 1}"
+            kind = "image" if slide.type == SlideType.Image else "video"
+            forward = _asset_for(
+                slide.file, kind, slide_id, "forward", assets_by_key
+            )
+            reverse = (
+                forward
+                if kind == "image"
+                else _asset_for(
+                    slide.rev_file,
+                    kind,
+                    slide_id,
+                    "reverse",
+                    assets_by_key,
+                )
+            )
+            slides.append(
+                {
+                    "autoNext": slide.auto_next,
+                    "backgroundColor": _color_css(presentation.background_color),
+                    "direction": slide.direction,
+                    "forward": _asset_reference(forward, one_file),
+                    "id": slide_id,
+                    "loop": slide.loop,
+                    "notes": slide.notes,
+                    "playbackRate": slide.playback_rate,
+                    "resolution": list(presentation.resolution),
+                    "reverse": _asset_reference(reverse, one_file),
+                    "reversedPlaybackRate": slide.reversed_playback_rate,
+                    "sceneIndex": scene_index,
+                    "slideIndex": slide_index,
+                    "type": kind,
+                }
+            )
+        presentations.append(
+            {
+                "backgroundColor": _color_css(presentation.background_color),
+                "count": len(presentation.slides),
+                "id": f"scene-{scene_index + 1}",
+                "resolution": list(presentation.resolution),
+                "start": start,
+            }
+        )
+
+    manifest: dict[str, Any] = {
+        "backgroundSize": background_size,
+        "presentations": presentations,
+        "slides": slides,
+        "title": title,
+        "version": 1,
+    }
+    return manifest, sorted(assets_by_key.values(), key=lambda asset: asset.id)
+
+
+def _write_base64(stream: TextIO, source: Path) -> None:
+    remainder = b""
+    with source.open("rb") as media:
+        for chunk in iter(lambda: media.read(3 * 1024 * 1024), b""):
+            data = remainder + chunk
+            complete = len(data) - (len(data) % 3)
+            if complete:
+                stream.write(base64.b64encode(data[:complete]).decode("ascii"))
+            remainder = data[complete:]
+    if remainder:
+        stream.write(base64.b64encode(remainder).decode("ascii"))
+
+
+def build_html_player(
+    presentation_configs: list[PresentationConfig],
+    dest: Path,
+    assets_dir_template: str,
+    one_file: bool,
+    title: str,
+    background_size: str,
+) -> PlayerBuildResult:
+    """Build an asset-backed or single-file first-party HTML presentation."""
+    if not presentation_configs:
+        raise ValueError("At least one presentation configuration is required.")
+
+    manifest, assets = _plan(
+        presentation_configs, title, background_size, one_file
+    )
+    dirname = dest.parent
+    assets_dir = Path(
+        assets_dir_template.format(
+            dirname=dirname, basename=dest.stem, ext=dest.suffix
+        )
+    )
+    full_assets_dir = dirname / assets_dir
+    template = _resource_text("player.html")
+    core = _resource_text("player-core.js")
+    runtime = _resource_text("player.js")
+    styles = _resource_text("player.css")
+
+    if one_file:
+        style_tag = f"<style>\n{styles}\n</style>"
+        script_tags = f"<script>\n{core}\n</script>\n<script>\n{runtime}\n</script>"
+    else:
+        full_assets_dir.mkdir(parents=True, exist_ok=True)
+        for asset in assets:
+            shutil.copyfile(asset.source, full_assets_dir / asset.filename)
+        (full_assets_dir / "player-core.js").write_text(core, encoding="utf-8")
+        (full_assets_dir / "player.js").write_text(runtime, encoding="utf-8")
+        (full_assets_dir / "player.css").write_text(styles, encoding="utf-8")
+        try:
+            relative_assets_dir = Path(os.path.relpath(full_assets_dir, dirname))
+        except ValueError as error:
+            raise ValueError(
+                "The HTML file and its assets directory must be on the same drive."
+            ) from error
+        prefix = quote(relative_assets_dir.as_posix().rstrip("/"), safe="/")
+        for slide in manifest["slides"]:
+            for role in ("forward", "reverse"):
+                reference = slide[role]
+                reference["url"] = f"{prefix}/{reference['url']}"
+        style_tag = f'<link rel="stylesheet" href="{prefix}/player.css">'
+        script_tags = (
+            f'<script src="{prefix}/player-core.js"></script>\n'
+            f'<script src="{prefix}/player.js"></script>'
+        )
+
+    rendered = (
+        template.replace("@@TITLE@@", html.escape(title, quote=True))
+        .replace("@@STYLES@@", style_tag)
+        .replace("@@MANIFEST@@", _safe_json(manifest))
+        .replace("@@SCRIPTS@@", script_tags)
+    )
+    before_payloads, after_payloads = rendered.split("@@PAYLOADS@@", 1)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("w", encoding="utf-8", newline="\n") as output:
+        output.write(before_payloads)
+        if one_file:
+            for asset in assets:
+                output.write(
+                    f'<script type="application/octet-stream" data-ms-asset="{asset.id}" '
+                    f'data-mime="{html.escape(asset.mime_type, quote=True)}">'
+                )
+                _write_base64(output, asset.source)
+                output.write("</script>\n")
+        output.write(after_payloads)
+
+    return PlayerBuildResult(
+        mode="portable" if one_file else "asset-backed",
+        asset_count=len(assets),
+        output_size=dest.stat().st_size,
+    )

--- a/manim_slides/html_player/converter.py
+++ b/manim_slides/html_player/converter.py
@@ -139,9 +139,7 @@ def _plan(
         for slide_index, slide in enumerate(presentation.slides):
             slide_id = f"scene-{scene_index + 1}-slide-{slide_index + 1}"
             kind = "image" if slide.type == SlideType.Image else "video"
-            forward = _asset_for(
-                slide.file, kind, slide_id, "forward", assets_by_key
-            )
+            forward = _asset_for(slide.file, kind, slide_id, "forward", assets_by_key)
             reverse = (
                 forward
                 if kind == "image"
@@ -216,14 +214,10 @@ def build_html_player(
     if not presentation_configs:
         raise ValueError("At least one presentation configuration is required.")
 
-    manifest, assets = _plan(
-        presentation_configs, title, background_size, one_file
-    )
+    manifest, assets = _plan(presentation_configs, title, background_size, one_file)
     dirname = dest.parent
     assets_dir = Path(
-        assets_dir_template.format(
-            dirname=dirname, basename=dest.stem, ext=dest.suffix
-        )
+        assets_dir_template.format(dirname=dirname, basename=dest.stem, ext=dest.suffix)
     )
     full_assets_dir = dirname / assets_dir
     template = _resource_text("player.html")

--- a/manim_slides/html_player/player-core.js
+++ b/manim_slides/html_player/player-core.js
@@ -127,6 +127,7 @@
           seek: "start",
           settleIndex: model.index,
           slideIndex: model.index,
+          userGesture: true,
         });
       case "JUMP": {
         const index = Math.max(0, Math.min(model.slideCount - 1, event.index));
@@ -162,6 +163,22 @@
       case "LOAD_READY":
         if (event.generation !== model.generation || !model.pending)
           return unchanged(model);
+        if (event.playable && event.requiresGesture && model.pending.autoplay) {
+          return {
+            model: {
+              ...model,
+              active: model.pending,
+              index: model.pending.slideIndex,
+              pending: null,
+              resumeStatus:
+                model.pending.role === "reverse"
+                  ? Status.PLAYING_REVERSE
+                  : Status.PLAYING_FORWARD,
+              status: Status.PAUSED,
+            },
+            effects: [],
+          };
+        }
         if (!event.playable || !model.pending.autoplay) {
           return {
             model: {

--- a/manim_slides/html_player/player-core.js
+++ b/manim_slides/html_player/player-core.js
@@ -1,0 +1,282 @@
+(function (root, factory) {
+  const core = factory();
+  if (typeof module === "object" && module.exports) module.exports = core;
+  else root.ManimSlidesPlayerCore = core;
+})(typeof globalThis === "object" ? globalThis : this, function () {
+  "use strict";
+
+  const Status = Object.freeze({
+    FAILED: "failed",
+    HELD_END: "held-at-end",
+    LOADING: "loading",
+    PAUSED: "paused",
+    PLAYING_FORWARD: "playing-forward",
+    PLAYING_REVERSE: "playing-reverse",
+    READY_START: "ready-at-start",
+    TRANSITIONING: "transitioning",
+  });
+
+  function initial(slideCount) {
+    return {
+      active: null,
+      error: null,
+      failedEffect: null,
+      generation: 0,
+      index: 0,
+      pending: null,
+      resumeStatus: null,
+      slideCount,
+      status: Status.LOADING,
+    };
+  }
+
+  function unchanged(model) {
+    return { model, effects: [] };
+  }
+
+  function mapReverseTime(forwardTime, forwardDuration, reverseDuration, tolerance = 0.15) {
+    if (
+      !Number.isFinite(forwardTime) ||
+      !Number.isFinite(forwardDuration) ||
+      !Number.isFinite(reverseDuration) ||
+      forwardDuration <= 0 ||
+      reverseDuration <= 0 ||
+      Math.abs(reverseDuration - forwardDuration) / forwardDuration > tolerance
+    ) {
+      return { fallback: true, time: 0 };
+    }
+    const ratio = Math.max(0, Math.min(1, forwardTime / forwardDuration));
+    return { fallback: false, time: reverseDuration * (1 - ratio) };
+  }
+
+  function load(model, details) {
+    const generation = model.generation + 1;
+    const effect = { ...details, type: "load", generation };
+    return {
+      model: {
+        ...model,
+        error: null,
+        failedEffect: null,
+        generation,
+        pending: effect,
+        resumeStatus: null,
+        status: Status.TRANSITIONING,
+      },
+      effects: [effect],
+    };
+  }
+
+  function transition(model, event, context = {}) {
+    const slides = context.slides || [];
+    const current = slides[model.index] || {};
+    switch (event.type) {
+      case "BOOT":
+        if (!model.slideCount) return unchanged(model);
+        return load(model, {
+          autoplay: true,
+          role: "forward",
+          seek: "start",
+          settleIndex: 0,
+          slideIndex: 0,
+        });
+      case "NEXT":
+        if (model.status === Status.PLAYING_FORWARD) {
+          const generation = model.generation + 1;
+          return {
+            model: { ...model, generation, status: Status.TRANSITIONING },
+            effects: [{ type: "hold", generation }],
+          };
+        }
+        if (
+          model.status === Status.PLAYING_REVERSE ||
+          (model.status === Status.PAUSED && model.resumeStatus === Status.PLAYING_REVERSE)
+        ) {
+          return load(model, {
+            autoplay: true,
+            mapFromActive: true,
+            role: "forward",
+            seek: "mapped",
+            settleIndex: model.index,
+            slideIndex: model.index,
+          });
+        }
+        if (model.index >= model.slideCount - 1) return unchanged(model);
+        return load(model, {
+          autoplay: true,
+          role: "forward",
+          seek: "start",
+          settleIndex: model.index + 1,
+          slideIndex: model.index + 1,
+        });
+      case "BACK":
+        if (model.index <= 0) return unchanged(model);
+        return load(model, {
+          autoplay: true,
+          mapFromActive:
+            model.status === Status.PLAYING_FORWARD ||
+            (model.status === Status.PAUSED && model.resumeStatus === Status.PLAYING_FORWARD),
+          role: "reverse",
+          seek: model.status === Status.HELD_END ? "start" : "mapped",
+          settleIndex: model.index - 1,
+          slideIndex: model.index,
+        });
+      case "REPLAY":
+        return load(model, {
+          autoplay: true,
+          role: "forward",
+          seek: "start",
+          settleIndex: model.index,
+          slideIndex: model.index,
+        });
+      case "JUMP": {
+        const index = Math.max(0, Math.min(model.slideCount - 1, event.index));
+        return load(model, {
+          autoplay: false,
+          role: "forward",
+          seek: "end",
+          settleIndex: index,
+          slideIndex: index,
+        });
+      }
+      case "TOGGLE_PAUSE":
+        if (
+          model.status === Status.PLAYING_FORWARD ||
+          model.status === Status.PLAYING_REVERSE
+        ) {
+          return {
+            model: {
+              ...model,
+              resumeStatus: model.status,
+              status: Status.PAUSED,
+            },
+            effects: [{ type: "pause" }],
+          };
+        }
+        if (model.status === Status.PAUSED && model.resumeStatus) {
+          return {
+            model: { ...model, status: model.resumeStatus },
+            effects: [{ type: "play", userGesture: true }],
+          };
+        }
+        return unchanged(model);
+      case "LOAD_READY":
+        if (event.generation !== model.generation || !model.pending)
+          return unchanged(model);
+        if (!event.playable || !model.pending.autoplay) {
+          return {
+            model: {
+              ...model,
+              active: model.pending,
+              index: model.pending.settleIndex,
+              pending: null,
+              status: Status.HELD_END,
+            },
+            effects: [],
+          };
+        }
+        return {
+          model: {
+            ...model,
+            active: model.pending,
+            index: model.pending.slideIndex,
+            pending: null,
+            status:
+              model.pending.role === "reverse"
+                ? Status.PLAYING_REVERSE
+                : Status.READY_START,
+          },
+          effects: [{ type: "play", generation: event.generation }],
+        };
+      case "PLAY_STARTED":
+        if (event.generation !== model.generation || !model.active)
+          return unchanged(model);
+        return {
+          model: {
+            ...model,
+            status:
+              model.active.role === "reverse"
+                ? Status.PLAYING_REVERSE
+                : Status.PLAYING_FORWARD,
+          },
+          effects: [],
+        };
+      case "PLAY_REJECTED":
+        if (event.generation !== model.generation) return unchanged(model);
+        return {
+          model: {
+            ...model,
+            resumeStatus:
+              model.active && model.active.role === "reverse"
+                ? Status.PLAYING_REVERSE
+                : Status.PLAYING_FORWARD,
+            status: Status.PAUSED,
+          },
+          effects: [],
+        };
+      case "HOLD_READY":
+        if (event.generation !== model.generation) return unchanged(model);
+        return {
+          model: { ...model, status: Status.HELD_END },
+          effects: [],
+        };
+      case "ENDED":
+        if (event.generation !== model.generation || !model.active)
+          return unchanged(model);
+        if (model.active.role === "reverse") {
+          return {
+            model: {
+              ...model,
+              index: model.active.settleIndex,
+              status: Status.HELD_END,
+            },
+            effects: [{ type: "hold-active" }],
+          };
+        }
+        if (current.loop) {
+          return {
+            model: { ...model, status: Status.PLAYING_FORWARD },
+            effects: [{ type: "replay-active" }],
+          };
+        }
+        if (current.autoNext && model.index < model.slideCount - 1) {
+          return load(model, {
+            autoplay: true,
+            role: "forward",
+            seek: "start",
+            settleIndex: model.index + 1,
+            slideIndex: model.index + 1,
+          });
+        }
+        return {
+          model: { ...model, status: Status.HELD_END },
+          effects: [{ type: "hold-active" }],
+        };
+      case "ERROR":
+        if (event.generation !== model.generation) return unchanged(model);
+        return {
+          model: {
+            ...model,
+            error: event.message,
+            failedEffect: model.pending || model.active,
+            pending: null,
+            status: Status.FAILED,
+          },
+          effects: [{ type: "pause" }],
+        };
+      case "RETRY":
+        if (!model.failedEffect) return unchanged(model);
+        return load(model, {
+          autoplay: model.failedEffect.autoplay,
+          mapFromActive: model.failedEffect.mapFromActive,
+          role: model.failedEffect.role,
+          seek: model.failedEffect.seek,
+          settleIndex: model.failedEffect.settleIndex,
+          slideIndex: model.failedEffect.slideIndex,
+        });
+      default:
+        return unchanged(model);
+    }
+  }
+
+  return { Status, initial, mapReverseTime, transition };
+});

--- a/manim_slides/html_player/player-core.js
+++ b/manim_slides/html_player/player-core.js
@@ -36,7 +36,12 @@
     return { model, effects: [] };
   }
 
-  function mapReverseTime(forwardTime, forwardDuration, reverseDuration, tolerance = 0.15) {
+  function mapReverseTime(
+    forwardTime,
+    forwardDuration,
+    reverseDuration,
+    tolerance = 0.15,
+  ) {
     if (
       !Number.isFinite(forwardTime) ||
       !Number.isFinite(forwardDuration) ||
@@ -45,10 +50,10 @@
       reverseDuration <= 0 ||
       Math.abs(reverseDuration - forwardDuration) / forwardDuration > tolerance
     ) {
-      return { fallback: true, time: 0 };
+      return { fallback: true, time: 0 }; // NOPMD - This is a returned object literal, not a block.
     }
     const ratio = Math.max(0, Math.min(1, forwardTime / forwardDuration));
-    return { fallback: false, time: reverseDuration * (1 - ratio) };
+    return { fallback: false, time: reverseDuration * (1 - ratio) }; // NOPMD - This is a returned object literal, not a block.
   }
 
   function load(model, details) {
@@ -103,7 +108,8 @@
         }
         if (
           model.status === Status.PLAYING_REVERSE ||
-          (model.status === Status.PAUSED && model.resumeStatus === Status.PLAYING_REVERSE)
+          (model.status === Status.PAUSED &&
+            model.resumeStatus === Status.PLAYING_REVERSE)
         ) {
           return load(model, {
             autoplay: true,
@@ -145,7 +151,8 @@
           autoplay: true,
           mapFromActive:
             model.status === Status.PLAYING_FORWARD ||
-            (model.status === Status.PAUSED && model.resumeStatus === Status.PLAYING_FORWARD),
+            (model.status === Status.PAUSED &&
+              model.resumeStatus === Status.PLAYING_FORWARD),
           role: "reverse",
           seek: model.status === Status.HELD_END ? "start" : "mapped",
           settleIndex: model.index - 1,

--- a/manim_slides/html_player/player-core.js
+++ b/manim_slides/html_player/player-core.js
@@ -19,11 +19,13 @@
   function initial(slideCount) {
     return {
       active: null,
+      animationOptIn: false,
       error: null,
       failedEffect: null,
       generation: 0,
       index: 0,
       pending: null,
+      presenting: false,
       resumeStatus: null,
       slideCount,
       status: Status.LOADING,
@@ -80,10 +82,22 @@
           slideIndex: 0,
         });
       case "NEXT":
-        if (model.status === Status.PLAYING_FORWARD) {
+        if (model.status === Status.TRANSITIONING && model.pending)
+          return unchanged(model);
+        if (
+          model.status === Status.PLAYING_FORWARD ||
+          model.status === Status.READY_START ||
+          (model.status === Status.PAUSED &&
+            model.resumeStatus === Status.PLAYING_FORWARD)
+        ) {
           const generation = model.generation + 1;
           return {
-            model: { ...model, generation, status: Status.TRANSITIONING },
+            model: {
+              ...model,
+              generation,
+              pending: null,
+              status: Status.TRANSITIONING,
+            },
             effects: [{ type: "hold", generation }],
           };
         }
@@ -109,7 +123,24 @@
           slideIndex: model.index + 1,
         });
       case "BACK":
+        if (model.status === Status.TRANSITIONING) return unchanged(model);
         if (model.index <= 0) return unchanged(model);
+        if (
+          model.status === Status.PLAYING_REVERSE ||
+          (model.status === Status.PAUSED &&
+            model.resumeStatus === Status.PLAYING_REVERSE)
+        ) {
+          const generation = model.generation + 1;
+          return {
+            model: {
+              ...model,
+              generation,
+              pending: null,
+              status: Status.TRANSITIONING,
+            },
+            effects: [{ type: "hold", generation }],
+          };
+        }
         return load(model, {
           autoplay: true,
           mapFromActive:
@@ -121,7 +152,7 @@
           slideIndex: model.index,
         });
       case "REPLAY":
-        return load(model, {
+        return load({ ...model, animationOptIn: true }, {
           autoplay: true,
           role: "forward",
           seek: "start",
@@ -155,11 +186,57 @@
         }
         if (model.status === Status.PAUSED && model.resumeStatus) {
           return {
-            model: { ...model, status: model.resumeStatus },
+            model: {
+              ...model,
+              animationOptIn: true,
+              status: model.resumeStatus,
+            },
             effects: [{ type: "play", userGesture: true }],
           };
         }
         return unchanged(model);
+      case "PLAY_WITH_CONSENT":
+        if (model.status !== Status.PAUSED || !model.resumeStatus)
+          return unchanged(model);
+        return {
+          model: {
+            ...model,
+            animationOptIn: true,
+            status: model.resumeStatus,
+          },
+          effects: [{ type: "play", userGesture: true }],
+        };
+      case "TOGGLE_PRESENT":
+        if (model.presenting) {
+          return {
+            model: { ...model, presenting: false },
+            effects: [{ type: "exit-fullscreen" }, { type: "focus-player" }],
+          };
+        }
+        return {
+          model: {
+            ...model,
+            animationOptIn: true,
+            presenting: true,
+            status:
+              model.status === Status.PAUSED && model.resumeStatus
+                ? model.resumeStatus
+                : model.status,
+          },
+          effects: [
+            ...(model.status === Status.PAUSED && model.resumeStatus
+              ? [{ type: "play", userGesture: true }]
+              : []),
+            { type: "request-fullscreen" },
+            { type: "focus-player" },
+          ],
+        };
+      case "FULLSCREEN_EXITED":
+        if (!model.presenting) return unchanged(model);
+        return {
+          model: { ...model, presenting: false },
+          effects: [{ type: "focus-player" }],
+        };
       case "LOAD_READY":
         if (event.generation !== model.generation || !model.pending)
           return unchanged(model);
@@ -233,7 +310,14 @@
       case "HOLD_READY":
         if (event.generation !== model.generation) return unchanged(model);
         return {
-          model: { ...model, status: Status.HELD_END },
+          model: {
+            ...model,
+            index:
+              model.active && model.active.role === "reverse"
+                ? model.active.settleIndex
+                : model.index,
+            status: Status.HELD_END,
+          },
           effects: [],
         };
       case "ENDED":

--- a/manim_slides/html_player/player-core.js
+++ b/manim_slides/html_player/player-core.js
@@ -152,14 +152,17 @@
           slideIndex: model.index,
         });
       case "REPLAY":
-        return load({ ...model, animationOptIn: true }, {
-          autoplay: true,
-          role: "forward",
-          seek: "start",
-          settleIndex: model.index,
-          slideIndex: model.index,
-          userGesture: true,
-        });
+        return load(
+          { ...model, animationOptIn: true },
+          {
+            autoplay: true,
+            role: "forward",
+            seek: "start",
+            settleIndex: model.index,
+            slideIndex: model.index,
+            userGesture: true,
+          },
+        );
       case "JUMP": {
         const index = Math.max(0, Math.min(model.slideCount - 1, event.index));
         return load(model, {

--- a/manim_slides/html_player/player.css
+++ b/manim_slides/html_player/player.css
@@ -1,0 +1,225 @@
+.ms-player-document {
+  margin: 0;
+  overflow: hidden;
+  background: #000;
+}
+
+.manim-slides-player,
+.manim-slides-player * {
+  box-sizing: border-box;
+}
+
+.manim-slides-player {
+  --ms-accent: #7dd3fc;
+  --ms-background: #000;
+  position: relative;
+  display: grid;
+  width: 100%;
+  height: 100dvh;
+  min-height: 100svh;
+  overflow: hidden;
+  color: #fff;
+  background: var(--ms-background);
+  font: 500 14px/1.35 system-ui, sans-serif;
+  outline: none;
+  isolation: isolate;
+}
+
+.manim-slides-player:focus-visible {
+  outline: 3px solid var(--ms-accent);
+  outline-offset: -3px;
+}
+
+.ms-stage {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  background: var(--ms-background);
+  touch-action: pan-y pinch-zoom;
+}
+
+[data-ms-standalone] .ms-stage {
+  touch-action: none;
+}
+
+.ms-media-slot {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  display: grid;
+  visibility: hidden;
+  place-items: center;
+  background: var(--ms-background);
+}
+
+.ms-media-slot.is-active {
+  z-index: 1;
+  visibility: visible;
+}
+
+.ms-media-slot video,
+.ms-media-slot img {
+  display: none;
+  width: 100%;
+  height: 100%;
+  background: var(--ms-background);
+  object-fit: var(--ms-fit, contain);
+}
+
+.ms-media-slot.is-video video,
+.ms-media-slot.is-image img {
+  display: block;
+}
+
+.ms-loading,
+.ms-gesture,
+.ms-error {
+  position: absolute;
+  z-index: 4;
+  top: 50%;
+  left: 50%;
+  max-width: min(90%, 38rem);
+  transform: translate(-50%, -50%);
+}
+
+.ms-loading,
+.ms-error {
+  padding: 1rem 1.25rem;
+  border-radius: .6rem;
+  background: rgb(0 0 0 / 78%);
+  text-align: center;
+}
+
+.ms-controls {
+  position: absolute;
+  z-index: 5;
+  right: max(.5rem, env(safe-area-inset-right));
+  bottom: max(.5rem, env(safe-area-inset-bottom));
+  left: max(.5rem, env(safe-area-inset-left));
+  display: flex;
+  gap: .35rem;
+  justify-content: center;
+  opacity: .18;
+  transition: opacity .15s ease;
+}
+
+.manim-slides-player:hover .ms-controls,
+.manim-slides-player:focus-within .ms-controls,
+.ms-controls:hover {
+  opacity: 1;
+}
+
+.manim-slides-player button {
+  min-width: 44px;
+  min-height: 44px;
+  padding: .55rem .75rem;
+  border: 1px solid rgb(255 255 255 / 35%);
+  border-radius: .45rem;
+  color: inherit;
+  background: rgb(0 0 0 / 78%);
+  font: inherit;
+  cursor: pointer;
+}
+
+.manim-slides-player button:focus-visible {
+  outline: 3px solid var(--ms-accent);
+  outline-offset: 2px;
+}
+
+.ms-position {
+  position: absolute;
+  z-index: 3;
+  top: max(.5rem, env(safe-area-inset-top));
+  right: max(.65rem, env(safe-area-inset-right));
+  padding: .25rem .45rem;
+  border-radius: .3rem;
+  background: rgb(0 0 0 / 62%);
+}
+
+.ms-progress {
+  position: absolute;
+  z-index: 3;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  border: 0;
+}
+
+.ms-notes,
+.ms-overview,
+.ms-help {
+  position: absolute;
+  z-index: 6;
+  overflow: auto;
+  border: 1px solid rgb(255 255 255 / 25%);
+  border-radius: .6rem;
+  background: rgb(12 15 20 / 96%);
+  box-shadow: 0 1rem 3rem rgb(0 0 0 / 45%);
+}
+
+.ms-notes {
+  right: max(.75rem, env(safe-area-inset-right));
+  bottom: calc(4rem + env(safe-area-inset-bottom));
+  left: max(.75rem, env(safe-area-inset-left));
+  max-height: 38%;
+  padding: 1rem;
+}
+
+.ms-notes pre {
+  margin: 0;
+  white-space: pre-wrap;
+  font: inherit;
+}
+
+.ms-overview,
+.ms-help {
+  inset: max(1rem, env(safe-area-inset-top)) max(1rem, env(safe-area-inset-right)) max(1rem, env(safe-area-inset-bottom)) max(1rem, env(safe-area-inset-left));
+  padding: 1rem;
+}
+
+.ms-overview > div {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: .6rem;
+}
+
+.ms-overview button[aria-current="true"] {
+  border-color: var(--ms-accent);
+}
+
+.ms-help dl {
+  display: grid;
+  grid-template-columns: minmax(9rem, auto) 1fr;
+  gap: .45rem 1rem;
+}
+
+.ms-help dt {
+  font-weight: 750;
+}
+
+.manim-slides-player [hidden] {
+  display: none !important;
+}
+
+@media (max-width: 42rem), (max-height: 28rem) {
+  .ms-controls {
+    overflow-x: auto;
+    justify-content: flex-start;
+  }
+
+  .ms-controls button {
+    flex: 0 0 auto;
+  }
+
+  .ms-help dl {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ms-controls {
+    transition: none;
+  }
+}

--- a/manim_slides/html_player/player.css
+++ b/manim_slides/html_player/player.css
@@ -113,9 +113,9 @@
   transition: opacity .15s ease;
 }
 
+.ms-controls:hover,
 .manim-slides-player:hover .ms-controls,
-.manim-slides-player:focus-within .ms-controls,
-.ms-controls:hover {
+.manim-slides-player:focus-within .ms-controls {
   opacity: 1;
 }
 

--- a/manim_slides/html_player/player.css
+++ b/manim_slides/html_player/player.css
@@ -30,6 +30,21 @@
   outline-offset: -3px;
 }
 
+.manim-slides-player.is-presenting {
+  position: fixed;
+  z-index: 2147483647;
+  inset: 0;
+  width: 100vw;
+  height: 100dvh;
+  min-height: 100svh;
+}
+
+.manim-slides-player.is-presenting .ms-controls,
+.manim-slides-player.is-presenting .ms-position,
+.manim-slides-player.is-presenting .ms-progress {
+  display: none;
+}
+
 .ms-stage {
   position: absolute;
   inset: 0;

--- a/manim_slides/html_player/player.css
+++ b/manim_slides/html_player/player.css
@@ -12,6 +12,7 @@
 .manim-slides-player {
   --ms-accent: #7dd3fc;
   --ms-background: #000;
+
   position: relative;
   display: grid;
   width: 100%;
@@ -37,12 +38,6 @@
   width: 100vw;
   height: 100dvh;
   min-height: 100svh;
-}
-
-.manim-slides-player.is-presenting .ms-controls,
-.manim-slides-player.is-presenting .ms-position,
-.manim-slides-player.is-presenting .ms-progress {
-  display: none;
 }
 
 .ms-stage {
@@ -160,6 +155,12 @@
   width: 100%;
   height: 3px;
   border: 0;
+}
+
+.manim-slides-player.is-presenting .ms-controls,
+.manim-slides-player.is-presenting .ms-position,
+.manim-slides-player.is-presenting .ms-progress {
+  display: none;
 }
 
 .ms-notes,

--- a/manim_slides/html_player/player.html
+++ b/manim_slides/html_player/player.html
@@ -27,7 +27,7 @@
         <button type="button" data-command="notes" aria-label="Toggle notes">Notes</button>
         <button type="button" data-command="overview" aria-label="Toggle overview">Overview</button>
         <button type="button" data-command="help" aria-label="Show keyboard help">?</button>
-        <button type="button" data-command="fullscreen" aria-label="Toggle fullscreen">⛶</button>
+        <button type="button" data-command="present" aria-label="Enter presentation mode" aria-keyshortcuts="F">Present</button>
       </nav>
       <div class="ms-position" data-ms-position aria-live="polite"></div>
       <progress class="ms-progress" data-ms-progress max="1" value="0" aria-label="Presentation progress"></progress>
@@ -35,7 +35,8 @@
       <section class="ms-overview" data-ms-overview hidden aria-label="Slide overview"><div data-ms-overview-list></div></section>
       <section class="ms-help" data-ms-help hidden role="dialog" aria-modal="false" aria-label="Keyboard help">
         <h2>Presentation controls</h2>
-        <dl><dt>Space, Right, Page Down</dt><dd>Next</dd><dt>Left, Page Up</dt><dd>Previous</dd><dt>R</dt><dd>Replay</dd><dt>P</dt><dd>Pause or resume</dd><dt>N</dt><dd>Notes</dd><dt>O</dt><dd>Overview</dd><dt>F</dt><dd>Fullscreen</dd><dt>Escape</dt><dd>Close overlay or leave fullscreen</dd></dl>
+        <p>With reduced motion, choose Play animation or Present once to enable animation for this player session.</p>
+        <dl><dt>Space, Right, Page Down</dt><dd>Finish the current animation; press again to advance</dd><dt>Left, Page Up</dt><dd>Finish active reverse playback or go back</dd><dt>R</dt><dd>Replay</dd><dt>P</dt><dd>Pause or resume</dd><dt>N</dt><dd>Notes</dd><dt>O</dt><dd>Overview</dd><dt>F</dt><dd>Enter or exit Present mode</dd><dt>Escape</dt><dd>Close an overlay or exit Present mode</dd></dl>
         <button type="button" data-command="help">Close</button>
       </section>
       <script type="application/json" data-ms-manifest>@@MANIFEST@@</script>

--- a/manim_slides/html_player/player.html
+++ b/manim_slides/html_player/player.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="color-scheme" content="dark">
+    <title>@@TITLE@@</title>
+    @@STYLES@@
+  </head>
+  <body class="ms-player-document">
+    <main class="manim-slides-player" data-ms-player data-ms-standalone tabindex="0" aria-label="Manim Slides presentation player">
+      <div class="ms-stage" data-ms-stage aria-live="off">
+        <div class="ms-media-slot is-active" data-ms-slot="0"><video playsinline preload="metadata"></video><img alt=""></div>
+        <div class="ms-media-slot" data-ms-slot="1"><video playsinline preload="metadata"></video><img alt=""></div>
+        <div class="ms-loading" data-ms-loading role="status">Loading presentation…</div>
+        <button class="ms-gesture" data-ms-gesture type="button" hidden>Play presentation</button>
+        <section class="ms-error" data-ms-error role="alert" hidden>
+          <p data-ms-error-message></p>
+          <div><button type="button" data-ms-retry>Retry</button><button type="button" data-command="back">Previous</button><button type="button" data-command="next">Next</button></div>
+        </section>
+      </div>
+      <nav class="ms-controls" aria-label="Presentation controls">
+        <button type="button" data-command="back" aria-label="Previous slide">◀</button>
+        <button type="button" data-command="replay" aria-label="Replay slide">↻</button>
+        <button type="button" data-command="pause" aria-label="Pause or resume">⏯</button>
+        <button type="button" data-command="next" aria-label="Next slide">▶</button>
+        <button type="button" data-command="notes" aria-label="Toggle notes">Notes</button>
+        <button type="button" data-command="overview" aria-label="Toggle overview">Overview</button>
+        <button type="button" data-command="help" aria-label="Show keyboard help">?</button>
+        <button type="button" data-command="fullscreen" aria-label="Toggle fullscreen">⛶</button>
+      </nav>
+      <div class="ms-position" data-ms-position aria-live="polite"></div>
+      <progress class="ms-progress" data-ms-progress max="1" value="0" aria-label="Presentation progress"></progress>
+      <aside class="ms-notes" data-ms-notes hidden aria-label="Slide notes"><pre data-ms-notes-text></pre></aside>
+      <section class="ms-overview" data-ms-overview hidden aria-label="Slide overview"><div data-ms-overview-list></div></section>
+      <section class="ms-help" data-ms-help hidden role="dialog" aria-modal="false" aria-label="Keyboard help">
+        <h2>Presentation controls</h2>
+        <dl><dt>Space, Right, Page Down</dt><dd>Next</dd><dt>Left, Page Up</dt><dd>Previous</dd><dt>R</dt><dd>Replay</dd><dt>P</dt><dd>Pause or resume</dd><dt>N</dt><dd>Notes</dd><dt>O</dt><dd>Overview</dd><dt>F</dt><dd>Fullscreen</dd><dt>Escape</dt><dd>Close overlay or leave fullscreen</dd></dl>
+        <button type="button" data-command="help">Close</button>
+      </section>
+      <script type="application/json" data-ms-manifest>@@MANIFEST@@</script>
+      @@PAYLOADS@@
+    </main>
+    @@SCRIPTS@@
+  </body>
+</html>

--- a/manim_slides/html_player/player.js
+++ b/manim_slides/html_player/player.js
@@ -19,19 +19,24 @@
         this.urls.set(asset.id, url);
         return url;
       }
-      const node = this.root.querySelector(`[data-ms-asset="${CSS.escape(asset.id)}"]`);
+      const node = this.root.querySelector(
+        `[data-ms-asset="${CSS.escape(asset.id)}"]`,
+      );
       if (!node) throw new Error(`Embedded asset '${asset.id}' is missing.`);
       const base64 = node.textContent.trim();
       const parts = [];
       const chunkSize = 1024 * 1024 - ((1024 * 1024) % 4);
       for (let offset = 0; offset < base64.length; offset += chunkSize) {
         const binary = atob(base64.slice(offset, offset + chunkSize));
-        const bytes = new Uint8Array(binary.length);
-        for (let index = 0; index < binary.length; index += 1)
-          bytes[index] = binary.charCodeAt(index);
+        const bytes = Uint8Array.from(binary, (character) =>
+          character.charCodeAt(0),
+        );
         parts.push(bytes);
       }
-      const url = URL.createObjectURL(new Blob(parts, { type: asset.mimeType }));
+      // eslint-disable-next-line compat/compat -- Self-contained media requires Blob URLs.
+      const url = URL.createObjectURL(
+        new Blob(parts, { type: asset.mimeType }),
+      );
       this.urls.set(asset.id, url);
       return url;
     }
@@ -40,13 +45,17 @@
       for (const [id, url] of this.urls) {
         if (this.urls.size <= this.limit) break;
         if (protectedIds.has(id)) continue;
+        // eslint-disable-next-line compat/compat -- Blob URL support is required above.
         URL.revokeObjectURL(url);
         this.urls.delete(id);
       }
     }
 
     destroy() {
-      for (const url of this.urls.values()) URL.revokeObjectURL(url);
+      for (const url of this.urls.values()) {
+        // eslint-disable-next-line compat/compat -- Blob URL support is required above.
+        URL.revokeObjectURL(url);
+      }
       this.urls.clear();
     }
   }
@@ -54,9 +63,13 @@
   class Player {
     constructor(root) {
       this.root = root;
-      this.manifest = JSON.parse(root.querySelector("[data-ms-manifest]").textContent);
+      this.manifest = JSON.parse(
+        root.querySelector("[data-ms-manifest]").textContent,
+      );
       if (this.manifest.version !== 1) {
-        throw new Error(`Unsupported player manifest version '${this.manifest.version}'.`);
+        throw new Error(
+          `Unsupported player manifest version '${this.manifest.version}'.`,
+        );
       }
       this.slides = this.manifest.slides;
       this.model = Core.initial(this.slides.length);
@@ -79,7 +92,9 @@
       this.help = root.querySelector("[data-ms-help]");
       this.overview = root.querySelector("[data-ms-overview]");
       this.overviewList = root.querySelector("[data-ms-overview-list]");
-      this.reducedMotion = matchMedia("(prefers-reduced-motion: reduce)").matches;
+      this.reducedMotion = matchMedia(
+        "(prefers-reduced-motion: reduce)",
+      ).matches;
       this.abort = new AbortController();
       this.pointer = null;
       this.suppressClick = false;
@@ -90,7 +105,9 @@
     }
 
     dispatch(event) {
-      const result = Core.transition(this.model, event, { slides: this.slides });
+      const result = Core.transition(this.model, event, {
+        slides: this.slides,
+      });
       this.model = result.model;
       this.render();
       for (const effect of result.effects) this.run(effect);
@@ -103,9 +120,12 @@
       else if (effect.type === "hold") this.hold(effect);
       else if (effect.type === "hold-active") this.holdActive();
       else if (effect.type === "replay-active") this.replayActive();
-      else if (effect.type === "request-fullscreen") this.requestPresentationFullscreen();
-      else if (effect.type === "exit-fullscreen") this.exitPresentationFullscreen();
-      else if (effect.type === "focus-player") this.root.focus({ preventScroll: true });
+      else if (effect.type === "request-fullscreen")
+        this.requestPresentationFullscreen();
+      else if (effect.type === "exit-fullscreen")
+        this.exitPresentationFullscreen();
+      else if (effect.type === "focus-player")
+        this.root.focus({ preventScroll: true });
     }
 
     currentSlot() {
@@ -118,14 +138,18 @@
     }
 
     safeEnd(video) {
-      return Number.isFinite(video.duration) ? Math.max(0, video.duration - 0.001) : 0;
+      return Number.isFinite(video.duration)
+        ? Math.max(0, video.duration - 0.001)
+        : 0;
     }
 
     waitFor(target, name, generation, rejectName = "error") {
+      // eslint-disable-next-line compat/compat -- The player targets modern browsers.
       return new Promise((resolve, reject) => {
         const done = () => {
           cleanup();
-          if (generation !== this.model.generation) reject(new DOMException("Stale operation", "AbortError"));
+          if (generation !== this.model.generation)
+            reject(new DOMException("Stale operation", "AbortError"));
           else resolve();
         };
         const failed = () => {
@@ -158,17 +182,25 @@
           });
         });
       } else {
-        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        await new Promise((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(resolve)),
+        );
       }
     }
 
     mappedTime(effect, duration) {
       if (!effect.mapFromActive) return 0;
       const active = this.currentVideo();
-      if (!active || !Number.isFinite(active.duration) || active.duration <= 0) return 0;
-      const mapping = Core.mapReverseTime(active.currentTime, active.duration, duration);
+      if (!active || !Number.isFinite(active.duration) || active.duration <= 0)
+        return 0;
+      const mapping = Core.mapReverseTime(
+        active.currentTime,
+        active.duration,
+        duration,
+      );
       if (mapping.fallback) {
-        this.loading.textContent = "Media durations differ; using full reverse playback.";
+        this.loading.textContent =
+          "Media durations differ; using full reverse playback.";
       }
       return mapping.time;
     }
@@ -178,7 +210,7 @@
       const slide = this.slides[effect.slideIndex];
       const asset = slide[effect.role];
       const slotIndex = 1 - this.activeSlot;
-      const slot = this.slots[slotIndex];
+      const slot = slotIndex === 0 ? this.slots[0] : this.slots[1];
       this.loading.hidden = false;
       this.loading.textContent = `Loading slide ${effect.slideIndex + 1} (${effect.role})…`;
       this.gesture.hidden = true;
@@ -199,14 +231,21 @@
           slot.node.classList.add("is-video");
           slot.video.muted = false;
           slot.video.playbackRate =
-            effect.role === "reverse" ? slide.reversedPlaybackRate : slide.playbackRate;
-          const metadata = this.waitFor(slot.video, "loadedmetadata", generation);
+            effect.role === "reverse"
+              ? slide.reversedPlaybackRate
+              : slide.playbackRate;
+          const metadata = this.waitFor(
+            slot.video,
+            "loadedmetadata",
+            generation,
+          );
           slot.video.src = url;
           slot.video.load();
           await metadata;
           let target = 0;
           if (effect.seek === "end") target = this.safeEnd(slot.video);
-          else if (effect.seek === "mapped") target = this.mappedTime(effect, slot.video.duration);
+          else if (effect.seek === "mapped")
+            target = this.mappedTime(effect, slot.video.duration);
           await this.seek(slot.video, target, generation);
         }
         if (generation !== this.model.generation) return;
@@ -215,7 +254,9 @@
         this.slots[this.activeSlot].node.classList.remove("is-active");
         slot.node.classList.add("is-active");
         this.activeSlot = slotIndex;
-        const protectedIds = new Set(this.slots.map((item) => item.assetId).filter(Boolean));
+        const protectedIds = new Set(
+          this.slots.map((item) => item.assetId).filter(Boolean),
+        );
         this.assetStore.trim(protectedIds);
         this.loading.hidden = true;
         this.dispatch({
@@ -281,7 +322,8 @@
       const video = this.currentVideo();
       if (!video) return;
       video.pause();
-      if (Number.isFinite(video.duration)) video.currentTime = this.safeEnd(video);
+      if (Number.isFinite(video.duration))
+        video.currentTime = this.safeEnd(video);
     }
 
     replayActive() {
@@ -292,7 +334,11 @@
     }
 
     async requestPresentationFullscreen() {
-      if (!this.root.requestFullscreen || document.fullscreenElement === this.root) return;
+      if (
+        !this.root.requestFullscreen ||
+        document.fullscreenElement === this.root
+      )
+        return;
       try {
         await this.root.requestFullscreen();
         if (!this.model.presenting && document.fullscreenElement === this.root)
@@ -303,7 +349,8 @@
     }
 
     async exitPresentationFullscreen() {
-      if (document.fullscreenElement !== this.root || !document.exitFullscreen) return;
+      if (document.fullscreenElement !== this.root || !document.exitFullscreen)
+        return;
       try {
         await document.exitFullscreen();
       } catch (_error) {
@@ -319,17 +366,22 @@
       this.root.dataset.animationOptIn = String(this.model.animationOptIn);
       this.root.dataset.presenting = String(this.model.presenting);
       this.root.classList.toggle("is-presenting", this.model.presenting);
-      this.position.textContent = total ? `${this.model.index + 1} / ${total}` : "0 / 0";
+      this.position.textContent = total
+        ? `${this.model.index + 1} / ${total}`
+        : "0 / 0";
       this.progress.max = Math.max(1, total - 1);
       this.progress.value = this.model.index;
       this.notesText.textContent = slide ? slide.notes : "";
       this.error.hidden = this.model.status !== Core.Status.FAILED;
       if (this.model.error) this.errorMessage.textContent = this.model.error;
       const needsGesture =
-        this.model.status === Core.Status.PAUSED && this.model.resumeStatus !== null;
+        this.model.status === Core.Status.PAUSED &&
+        this.model.resumeStatus !== null;
       this.gesture.hidden = !needsGesture;
       if (needsGesture)
-        this.gesture.textContent = this.reducedMotion ? "Play animation" : "Play presentation";
+        this.gesture.textContent = this.reducedMotion
+          ? "Play animation"
+          : "Play presentation";
       const forwardWillFinish =
         this.model.status === Core.Status.PLAYING_FORWARD ||
         this.model.status === Core.Status.READY_START ||
@@ -342,7 +394,10 @@
           forwardWillFinish ? "Finish current animation" : "Next slide",
         );
       for (const button of this.overviewList.querySelectorAll("button"))
-        button.setAttribute("aria-current", String(Number(button.dataset.index) === this.model.index));
+        button.setAttribute(
+          "aria-current",
+          String(Number(button.dataset.index) === this.model.index),
+        );
     }
 
     buildOverview() {
@@ -366,7 +421,8 @@
       else if (name === "replay") this.dispatch({ type: "REPLAY" });
       else if (name === "pause") this.dispatch({ type: "TOGGLE_PAUSE" });
       else if (name === "notes") this.notes.hidden = !this.notes.hidden;
-      else if (name === "overview") this.overview.hidden = !this.overview.hidden;
+      else if (name === "overview")
+        this.overview.hidden = !this.overview.hidden;
       else if (name === "help") this.help.hidden = !this.help.hidden;
       else if (name === "present") this.dispatch({ type: "TOGGLE_PRESENT" });
     }
@@ -386,7 +442,10 @@
       this.root.addEventListener(
         "keydown",
         (event) => {
-          if (event.target.closest("input, textarea, select, [contenteditable]")) return;
+          if (
+            event.target.closest("input, textarea, select, [contenteditable]")
+          )
+            return;
           const map = {
             " ": "next",
             ArrowRight: "next",
@@ -449,10 +508,26 @@
         { signal },
       );
       const stage = this.root.querySelector("[data-ms-stage]");
-      stage.addEventListener("pointerdown", (event) => this.pointerDown(event), { signal });
-      stage.addEventListener("pointermove", (event) => this.pointerMove(event), { signal });
-      stage.addEventListener("pointerup", (event) => this.pointerUp(event), { signal });
-      stage.addEventListener("pointercancel", () => { this.pointer = null; }, { signal });
+      stage.addEventListener(
+        "pointerdown",
+        (event) => this.pointerDown(event),
+        { signal },
+      );
+      stage.addEventListener(
+        "pointermove",
+        (event) => this.pointerMove(event),
+        { signal },
+      );
+      stage.addEventListener("pointerup", (event) => this.pointerUp(event), {
+        signal,
+      });
+      stage.addEventListener(
+        "pointercancel",
+        () => {
+          this.pointer = null;
+        },
+        { signal },
+      );
       stage.addEventListener(
         "click",
         (event) => {
@@ -460,14 +535,18 @@
             this.suppressClick = false;
             return;
           }
-          if (event.button === 0 && !event.target.closest("button, a, input, select, textarea")) {
+          if (
+            event.button === 0 &&
+            !event.target.closest("button, a, input, select, textarea")
+          ) {
             this.root.focus({ preventScroll: true });
             this.command("next");
           }
         },
         { signal },
       );
-      if (this.root.hasAttribute("data-ms-standalone")) this.root.focus({ preventScroll: true });
+      if (this.root.hasAttribute("data-ms-standalone"))
+        this.root.focus({ preventScroll: true });
       document.addEventListener(
         "fullscreenchange",
         () => {
@@ -476,7 +555,10 @@
         },
         { signal },
       );
-      addEventListener("pagehide", () => this.destroy(), { once: true, signal });
+      addEventListener("pagehide", () => this.destroy(), {
+        once: true,
+        signal,
+      });
     }
 
     pointerDown(event) {
@@ -511,8 +593,16 @@
       if (distance < 48 || velocity < 0.25) return;
       let command = null;
       if (Math.abs(dx) >= Math.abs(dy)) command = dx < 0 ? "next" : "back";
-      else if (dy < 0 && this.slides[this.model.index + 1]?.direction === "vertical") command = "next";
-      else if (dy > 0 && this.slides[this.model.index]?.direction === "vertical") command = "back";
+      else if (
+        dy < 0 &&
+        this.slides[this.model.index + 1]?.direction === "vertical"
+      )
+        command = "next";
+      else if (
+        dy > 0 &&
+        this.slides[this.model.index]?.direction === "vertical"
+      )
+        command = "back";
       if (command) {
         this.suppressClick = true;
         this.root.focus({ preventScroll: true });
@@ -532,11 +622,12 @@
   }
 
   for (const root of document.querySelectorAll("[data-ms-player]")) {
-    try {
+    try /* NOPMD - Each player needs an isolated initialization failure boundary. */ {
       root.manimSlidesPlayer = new Player(root);
     } catch (error) {
       const status = root.querySelector("[data-ms-loading]");
-      if (status) status.textContent = `Player initialization failed: ${error.message || error}`;
+      if (status)
+        status.textContent = `Player initialization failed: ${error.message || error}`;
       root.dataset.state = "failed";
     }
   }

--- a/manim_slides/html_player/player.js
+++ b/manim_slides/html_player/player.js
@@ -202,7 +202,7 @@
           slot.video.load();
           await metadata;
           let target = 0;
-          if (effect.seek === "end" || this.reducedMotion) target = this.safeEnd(slot.video);
+          if (effect.seek === "end") target = this.safeEnd(slot.video);
           else if (effect.seek === "mapped") target = this.mappedTime(effect, slot.video.duration);
           await this.seek(slot.video, target, generation);
         }
@@ -218,7 +218,12 @@
         this.dispatch({
           type: "LOAD_READY",
           generation,
-          playable: asset.kind === "video" && !this.reducedMotion,
+          playable: asset.kind === "video",
+          requiresGesture:
+            asset.kind === "video" &&
+            this.reducedMotion &&
+            effect.autoplay &&
+            !effect.userGesture,
         });
       } catch (error) {
         if (error && error.name === "AbortError") return;
@@ -297,7 +302,8 @@
       const needsGesture =
         this.model.status === Core.Status.PAUSED && this.model.resumeStatus !== null;
       this.gesture.hidden = !needsGesture;
-      if (needsGesture) this.gesture.textContent = "Play presentation";
+      if (needsGesture)
+        this.gesture.textContent = this.reducedMotion ? "Play animation" : "Play presentation";
       for (const button of this.overviewList.querySelectorAll("button"))
         button.setAttribute("aria-current", String(Number(button.dataset.index) === this.model.index));
     }

--- a/manim_slides/html_player/player.js
+++ b/manim_slides/html_player/player.js
@@ -1,0 +1,489 @@
+(function () {
+  "use strict";
+
+  const Core = globalThis.ManimSlidesPlayerCore;
+  if (!Core) throw new Error("Manim Slides player core did not load.");
+
+  class AssetStore {
+    constructor(root, limit = 6) {
+      this.root = root;
+      this.limit = limit;
+      this.urls = new Map();
+    }
+
+    get(asset) {
+      if (asset.storage === "file") return asset.url;
+      if (this.urls.has(asset.id)) {
+        const url = this.urls.get(asset.id);
+        this.urls.delete(asset.id);
+        this.urls.set(asset.id, url);
+        return url;
+      }
+      const node = this.root.querySelector(`[data-ms-asset="${CSS.escape(asset.id)}"]`);
+      if (!node) throw new Error(`Embedded asset '${asset.id}' is missing.`);
+      const base64 = node.textContent.trim();
+      const parts = [];
+      const chunkSize = 1024 * 1024 - ((1024 * 1024) % 4);
+      for (let offset = 0; offset < base64.length; offset += chunkSize) {
+        const binary = atob(base64.slice(offset, offset + chunkSize));
+        const bytes = new Uint8Array(binary.length);
+        for (let index = 0; index < binary.length; index += 1)
+          bytes[index] = binary.charCodeAt(index);
+        parts.push(bytes);
+      }
+      const url = URL.createObjectURL(new Blob(parts, { type: asset.mimeType }));
+      this.urls.set(asset.id, url);
+      return url;
+    }
+
+    trim(protectedIds = new Set()) {
+      for (const [id, url] of this.urls) {
+        if (this.urls.size <= this.limit) break;
+        if (protectedIds.has(id)) continue;
+        URL.revokeObjectURL(url);
+        this.urls.delete(id);
+      }
+    }
+
+    destroy() {
+      for (const url of this.urls.values()) URL.revokeObjectURL(url);
+      this.urls.clear();
+    }
+  }
+
+  class Player {
+    constructor(root) {
+      this.root = root;
+      this.manifest = JSON.parse(root.querySelector("[data-ms-manifest]").textContent);
+      if (this.manifest.version !== 1) {
+        throw new Error(`Unsupported player manifest version '${this.manifest.version}'.`);
+      }
+      this.slides = this.manifest.slides;
+      this.model = Core.initial(this.slides.length);
+      this.assetStore = new AssetStore(root);
+      this.slots = [...root.querySelectorAll("[data-ms-slot]")].map((node) => ({
+        node,
+        video: node.querySelector("video"),
+        image: node.querySelector("img"),
+        assetId: null,
+      }));
+      this.activeSlot = 0;
+      this.loading = root.querySelector("[data-ms-loading]");
+      this.gesture = root.querySelector("[data-ms-gesture]");
+      this.error = root.querySelector("[data-ms-error]");
+      this.errorMessage = root.querySelector("[data-ms-error-message]");
+      this.position = root.querySelector("[data-ms-position]");
+      this.progress = root.querySelector("[data-ms-progress]");
+      this.notes = root.querySelector("[data-ms-notes]");
+      this.notesText = root.querySelector("[data-ms-notes-text]");
+      this.help = root.querySelector("[data-ms-help]");
+      this.overview = root.querySelector("[data-ms-overview]");
+      this.overviewList = root.querySelector("[data-ms-overview-list]");
+      this.reducedMotion = matchMedia("(prefers-reduced-motion: reduce)").matches;
+      this.abort = new AbortController();
+      this.pointer = null;
+      this.suppressClick = false;
+      this.buildOverview();
+      this.bindInputs();
+      this.render();
+      this.dispatch({ type: "BOOT" });
+    }
+
+    dispatch(event) {
+      const result = Core.transition(this.model, event, { slides: this.slides });
+      this.model = result.model;
+      this.render();
+      for (const effect of result.effects) this.run(effect);
+    }
+
+    run(effect) {
+      if (effect.type === "load") this.load(effect);
+      else if (effect.type === "play") this.play(effect);
+      else if (effect.type === "pause") this.currentVideo()?.pause();
+      else if (effect.type === "hold") this.hold(effect);
+      else if (effect.type === "hold-active") this.holdActive();
+      else if (effect.type === "replay-active") this.replayActive();
+    }
+
+    currentSlot() {
+      return this.slots[this.activeSlot];
+    }
+
+    currentVideo() {
+      const slot = this.currentSlot();
+      return slot.node.classList.contains("is-video") ? slot.video : null;
+    }
+
+    safeEnd(video) {
+      return Number.isFinite(video.duration) ? Math.max(0, video.duration - 0.001) : 0;
+    }
+
+    waitFor(target, name, generation, rejectName = "error") {
+      return new Promise((resolve, reject) => {
+        const done = () => {
+          cleanup();
+          if (generation !== this.model.generation) reject(new DOMException("Stale operation", "AbortError"));
+          else resolve();
+        };
+        const failed = () => {
+          cleanup();
+          reject(new Error(`${rejectName} while loading media`));
+        };
+        const cleanup = () => {
+          target.removeEventListener(name, done);
+          target.removeEventListener(rejectName, failed);
+        };
+        target.addEventListener(name, done, { once: true });
+        target.addEventListener(rejectName, failed, { once: true });
+      });
+    }
+
+    async seek(video, time, generation) {
+      const target = Math.max(0, Math.min(this.safeEnd(video), time));
+      if (Math.abs(video.currentTime - target) < 0.002) return;
+      const ready = this.waitFor(video, "seeked", generation);
+      video.currentTime = target;
+      await ready;
+      if ("requestVideoFrameCallback" in video) {
+        await new Promise((resolve, reject) => {
+          const timeout = setTimeout(resolve, 180);
+          video.requestVideoFrameCallback(() => {
+            clearTimeout(timeout);
+            if (generation !== this.model.generation)
+              reject(new DOMException("Stale operation", "AbortError"));
+            else resolve();
+          });
+        });
+      } else {
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      }
+    }
+
+    mappedTime(effect, duration) {
+      if (!effect.mapFromActive) return 0;
+      const active = this.currentVideo();
+      if (!active || !Number.isFinite(active.duration) || active.duration <= 0) return 0;
+      const mapping = Core.mapReverseTime(active.currentTime, active.duration, duration);
+      if (mapping.fallback) {
+        this.loading.textContent = "Media durations differ; using full reverse playback.";
+      }
+      return mapping.time;
+    }
+
+    async load(effect) {
+      const generation = effect.generation;
+      const slide = this.slides[effect.slideIndex];
+      const asset = slide[effect.role];
+      const slotIndex = 1 - this.activeSlot;
+      const slot = this.slots[slotIndex];
+      this.loading.hidden = false;
+      this.loading.textContent = `Loading slide ${effect.slideIndex + 1} (${effect.role})…`;
+      this.gesture.hidden = true;
+      this.error.hidden = true;
+      slot.video.pause();
+      slot.video.removeAttribute("src");
+      slot.image.removeAttribute("src");
+      slot.node.classList.remove("is-video", "is-image");
+      try {
+        const url = this.assetStore.get(asset);
+        if (asset.kind === "image") {
+          slot.node.classList.add("is-image");
+          const loaded = this.waitFor(slot.image, "load", generation);
+          slot.image.src = url;
+          await loaded;
+          if (slot.image.decode) await slot.image.decode();
+        } else {
+          slot.node.classList.add("is-video");
+          slot.video.muted = false;
+          slot.video.playbackRate =
+            effect.role === "reverse" ? slide.reversedPlaybackRate : slide.playbackRate;
+          const metadata = this.waitFor(slot.video, "loadedmetadata", generation);
+          slot.video.src = url;
+          slot.video.load();
+          await metadata;
+          let target = 0;
+          if (effect.seek === "end" || this.reducedMotion) target = this.safeEnd(slot.video);
+          else if (effect.seek === "mapped") target = this.mappedTime(effect, slot.video.duration);
+          await this.seek(slot.video, target, generation);
+        }
+        if (generation !== this.model.generation) return;
+        slot.assetId = asset.id;
+        this.applySlideAppearance(slide);
+        this.slots[this.activeSlot].node.classList.remove("is-active");
+        slot.node.classList.add("is-active");
+        this.activeSlot = slotIndex;
+        const protectedIds = new Set(this.slots.map((item) => item.assetId).filter(Boolean));
+        this.assetStore.trim(protectedIds);
+        this.loading.hidden = true;
+        this.dispatch({
+          type: "LOAD_READY",
+          generation,
+          playable: asset.kind === "video" && !this.reducedMotion,
+        });
+      } catch (error) {
+        if (error && error.name === "AbortError") return;
+        this.dispatch({
+          type: "ERROR",
+          generation,
+          message: `Slide ${effect.slideIndex + 1} ${effect.role} asset '${asset.id}' could not be loaded: ${error.message || error}`,
+        });
+      }
+    }
+
+    applySlideAppearance(slide) {
+      const [width, height] = slide.resolution;
+      this.root.style.setProperty("--ms-background", slide.backgroundColor);
+      this.root.style.setProperty("--ms-fit", this.manifest.backgroundSize);
+      this.root.style.aspectRatio = `${width} / ${height}`;
+    }
+
+    async play(effect) {
+      const video = this.currentVideo();
+      const generation = effect.generation ?? this.model.generation;
+      if (!video) return;
+      video.onended = () => this.dispatch({ type: "ENDED", generation });
+      video.onerror = () =>
+        this.dispatch({
+          type: "ERROR",
+          generation,
+          message: `Slide ${this.model.index + 1} media decoding failed.`,
+        });
+      try {
+        await video.play();
+        this.dispatch({ type: "PLAY_STARTED", generation });
+      } catch (error) {
+        this.dispatch({ type: "PLAY_REJECTED", generation });
+      }
+    }
+
+    async hold(effect) {
+      const video = this.currentVideo();
+      if (video) {
+        video.pause();
+        try {
+          await this.seek(video, this.safeEnd(video), effect.generation);
+        } catch (error) {
+          if (error.name === "AbortError") return;
+        }
+      }
+      this.dispatch({ type: "HOLD_READY", generation: effect.generation });
+    }
+
+    holdActive() {
+      const video = this.currentVideo();
+      if (!video) return;
+      video.pause();
+      if (Number.isFinite(video.duration)) video.currentTime = this.safeEnd(video);
+    }
+
+    replayActive() {
+      const video = this.currentVideo();
+      if (!video) return;
+      video.currentTime = 0;
+      this.play({ generation: this.model.generation });
+    }
+
+    render() {
+      const slide = this.slides[this.model.index];
+      const total = this.slides.length;
+      this.root.dataset.state = this.model.status;
+      this.root.dataset.slideIndex = String(this.model.index);
+      this.position.textContent = total ? `${this.model.index + 1} / ${total}` : "0 / 0";
+      this.progress.max = Math.max(1, total - 1);
+      this.progress.value = this.model.index;
+      this.notesText.textContent = slide ? slide.notes : "";
+      this.error.hidden = this.model.status !== Core.Status.FAILED;
+      if (this.model.error) this.errorMessage.textContent = this.model.error;
+      const needsGesture =
+        this.model.status === Core.Status.PAUSED && this.model.resumeStatus !== null;
+      this.gesture.hidden = !needsGesture;
+      if (needsGesture) this.gesture.textContent = "Play presentation";
+      for (const button of this.overviewList.querySelectorAll("button"))
+        button.setAttribute("aria-current", String(Number(button.dataset.index) === this.model.index));
+    }
+
+    buildOverview() {
+      this.slides.forEach((slide, index) => {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.dataset.index = String(index);
+        button.textContent = `Slide ${index + 1}${slide.direction === "vertical" ? " ↓" : ""}`;
+        button.addEventListener("click", () => {
+          this.overview.hidden = true;
+          this.root.focus({ preventScroll: true });
+          this.dispatch({ type: "JUMP", index });
+        });
+        this.overviewList.append(button);
+      });
+    }
+
+    command(name) {
+      if (name === "next") this.dispatch({ type: "NEXT" });
+      else if (name === "back") this.dispatch({ type: "BACK" });
+      else if (name === "replay") this.dispatch({ type: "REPLAY" });
+      else if (name === "pause") this.dispatch({ type: "TOGGLE_PAUSE" });
+      else if (name === "notes") this.notes.hidden = !this.notes.hidden;
+      else if (name === "overview") this.overview.hidden = !this.overview.hidden;
+      else if (name === "help") this.help.hidden = !this.help.hidden;
+      else if (name === "fullscreen") this.toggleFullscreen();
+    }
+
+    toggleFullscreen() {
+      if (document.fullscreenElement) document.exitFullscreen?.();
+      else this.root.requestFullscreen?.();
+    }
+
+    closeOverlays() {
+      if (!this.help.hidden || !this.overview.hidden || !this.notes.hidden) {
+        this.help.hidden = true;
+        this.overview.hidden = true;
+        this.notes.hidden = true;
+        return true;
+      }
+      return false;
+    }
+
+    bindInputs() {
+      const signal = this.abort.signal;
+      this.root.addEventListener(
+        "keydown",
+        (event) => {
+          if (event.target.closest("input, textarea, select, [contenteditable]")) return;
+          const map = {
+            " ": "next",
+            ArrowRight: "next",
+            PageDown: "next",
+            ArrowLeft: "back",
+            PageUp: "back",
+            r: "replay",
+            R: "replay",
+            p: "pause",
+            P: "pause",
+            n: "notes",
+            N: "notes",
+            o: "overview",
+            O: "overview",
+            f: "fullscreen",
+            F: "fullscreen",
+            "?": "help",
+          };
+          if (event.key === "Escape") {
+            if (this.closeOverlays()) event.preventDefault();
+            return;
+          }
+          const command = map[event.key];
+          if (command) {
+            event.preventDefault();
+            this.command(command);
+          }
+        },
+        { signal },
+      );
+      this.root.querySelectorAll("[data-command]").forEach((button) =>
+        button.addEventListener("click", (event) => {
+          event.stopPropagation();
+          this.command(button.dataset.command);
+        }, { signal }),
+      );
+      this.root.querySelector("[data-ms-retry]").addEventListener(
+        "click",
+        (event) => {
+          event.stopPropagation();
+          this.dispatch({ type: "RETRY" });
+        },
+        { signal },
+      );
+      this.gesture.addEventListener(
+        "click",
+        (event) => {
+          event.stopPropagation();
+          this.root.focus({ preventScroll: true });
+          this.dispatch({ type: "TOGGLE_PAUSE" });
+        },
+        { signal },
+      );
+      const stage = this.root.querySelector("[data-ms-stage]");
+      stage.addEventListener("pointerdown", (event) => this.pointerDown(event), { signal });
+      stage.addEventListener("pointermove", (event) => this.pointerMove(event), { signal });
+      stage.addEventListener("pointerup", (event) => this.pointerUp(event), { signal });
+      stage.addEventListener("pointercancel", () => { this.pointer = null; }, { signal });
+      stage.addEventListener(
+        "click",
+        (event) => {
+          if (this.suppressClick) {
+            this.suppressClick = false;
+            return;
+          }
+          if (event.button === 0 && !event.target.closest("button, a, input, select, textarea")) {
+            this.root.focus({ preventScroll: true });
+            this.command("next");
+          }
+        },
+        { signal },
+      );
+      if (this.root.hasAttribute("data-ms-standalone")) this.root.focus({ preventScroll: true });
+      addEventListener("pagehide", () => this.destroy(), { once: true, signal });
+    }
+
+    pointerDown(event) {
+      if (!event.isPrimary || event.button !== 0) return;
+      this.pointer = {
+        id: event.pointerId,
+        x: event.clientX,
+        y: event.clientY,
+        lastX: event.clientX,
+        lastY: event.clientY,
+        time: event.timeStamp,
+        lastTime: event.timeStamp,
+      };
+    }
+
+    pointerMove(event) {
+      if (!this.pointer || event.pointerId !== this.pointer.id) return;
+      this.pointer.lastX = event.clientX;
+      this.pointer.lastY = event.clientY;
+      this.pointer.lastTime = event.timeStamp;
+    }
+
+    pointerUp(event) {
+      if (!this.pointer || event.pointerId !== this.pointer.id) return;
+      const pointer = this.pointer;
+      this.pointer = null;
+      const dx = event.clientX - pointer.x;
+      const dy = event.clientY - pointer.y;
+      const elapsed = Math.max(1, event.timeStamp - pointer.time);
+      const distance = Math.hypot(dx, dy);
+      const velocity = distance / elapsed;
+      if (distance < 48 || velocity < 0.25) return;
+      let command = null;
+      if (Math.abs(dx) >= Math.abs(dy)) command = dx < 0 ? "next" : "back";
+      else if (dy < 0 && this.slides[this.model.index + 1]?.direction === "vertical") command = "next";
+      else if (dy > 0 && this.slides[this.model.index]?.direction === "vertical") command = "back";
+      if (command) {
+        this.suppressClick = true;
+        this.root.focus({ preventScroll: true });
+        this.command(command);
+      }
+    }
+
+    destroy() {
+      this.abort.abort();
+      for (const slot of this.slots) {
+        slot.video.pause();
+        slot.video.removeAttribute("src");
+        slot.image.removeAttribute("src");
+      }
+      this.assetStore.destroy();
+    }
+  }
+
+  for (const root of document.querySelectorAll("[data-ms-player]")) {
+    try {
+      root.manimSlidesPlayer = new Player(root);
+    } catch (error) {
+      const status = root.querySelector("[data-ms-loading]");
+      if (status) status.textContent = `Player initialization failed: ${error.message || error}`;
+      root.dataset.state = "failed";
+    }
+  }
+})();

--- a/manim_slides/html_player/player.js
+++ b/manim_slides/html_player/player.js
@@ -422,10 +422,14 @@
         { signal },
       );
       this.root.querySelectorAll("[data-command]").forEach((button) =>
-        button.addEventListener("click", (event) => {
-          event.stopPropagation();
-          this.command(button.dataset.command);
-        }, { signal }),
+        button.addEventListener(
+          "click",
+          (event) => {
+            event.stopPropagation();
+            this.command(button.dataset.command);
+          },
+          { signal },
+        ),
       );
       this.root.querySelector("[data-ms-retry]").addEventListener(
         "click",

--- a/manim_slides/html_player/player.js
+++ b/manim_slides/html_player/player.js
@@ -103,6 +103,9 @@
       else if (effect.type === "hold") this.hold(effect);
       else if (effect.type === "hold-active") this.holdActive();
       else if (effect.type === "replay-active") this.replayActive();
+      else if (effect.type === "request-fullscreen") this.requestPresentationFullscreen();
+      else if (effect.type === "exit-fullscreen") this.exitPresentationFullscreen();
+      else if (effect.type === "focus-player") this.root.focus({ preventScroll: true });
     }
 
     currentSlot() {
@@ -223,7 +226,7 @@
             asset.kind === "video" &&
             this.reducedMotion &&
             effect.autoplay &&
-            !effect.userGesture,
+            !this.model.animationOptIn,
         });
       } catch (error) {
         if (error && error.name === "AbortError") return;
@@ -288,11 +291,34 @@
       this.play({ generation: this.model.generation });
     }
 
+    async requestPresentationFullscreen() {
+      if (!this.root.requestFullscreen || document.fullscreenElement === this.root) return;
+      try {
+        await this.root.requestFullscreen();
+        if (!this.model.presenting && document.fullscreenElement === this.root)
+          await document.exitFullscreen?.();
+      } catch (_error) {
+        // Present mode remains useful when fullscreen is unavailable or denied.
+      }
+    }
+
+    async exitPresentationFullscreen() {
+      if (document.fullscreenElement !== this.root || !document.exitFullscreen) return;
+      try {
+        await document.exitFullscreen();
+      } catch (_error) {
+        // The fullscreenchange handler remains the source of synchronization.
+      }
+    }
+
     render() {
       const slide = this.slides[this.model.index];
       const total = this.slides.length;
       this.root.dataset.state = this.model.status;
       this.root.dataset.slideIndex = String(this.model.index);
+      this.root.dataset.animationOptIn = String(this.model.animationOptIn);
+      this.root.dataset.presenting = String(this.model.presenting);
+      this.root.classList.toggle("is-presenting", this.model.presenting);
       this.position.textContent = total ? `${this.model.index + 1} / ${total}` : "0 / 0";
       this.progress.max = Math.max(1, total - 1);
       this.progress.value = this.model.index;
@@ -304,6 +330,17 @@
       this.gesture.hidden = !needsGesture;
       if (needsGesture)
         this.gesture.textContent = this.reducedMotion ? "Play animation" : "Play presentation";
+      const forwardWillFinish =
+        this.model.status === Core.Status.PLAYING_FORWARD ||
+        this.model.status === Core.Status.READY_START ||
+        (this.model.status === Core.Status.PAUSED &&
+          this.model.resumeStatus === Core.Status.PLAYING_FORWARD);
+      this.root
+        .querySelector("nav [data-command=next]")
+        .setAttribute(
+          "aria-label",
+          forwardWillFinish ? "Finish current animation" : "Next slide",
+        );
       for (const button of this.overviewList.querySelectorAll("button"))
         button.setAttribute("aria-current", String(Number(button.dataset.index) === this.model.index));
     }
@@ -331,12 +368,7 @@
       else if (name === "notes") this.notes.hidden = !this.notes.hidden;
       else if (name === "overview") this.overview.hidden = !this.overview.hidden;
       else if (name === "help") this.help.hidden = !this.help.hidden;
-      else if (name === "fullscreen") this.toggleFullscreen();
-    }
-
-    toggleFullscreen() {
-      if (document.fullscreenElement) document.exitFullscreen?.();
-      else this.root.requestFullscreen?.();
+      else if (name === "present") this.dispatch({ type: "TOGGLE_PRESENT" });
     }
 
     closeOverlays() {
@@ -369,12 +401,16 @@
             N: "notes",
             o: "overview",
             O: "overview",
-            f: "fullscreen",
-            F: "fullscreen",
+            f: "present",
+            F: "present",
             "?": "help",
           };
           if (event.key === "Escape") {
             if (this.closeOverlays()) event.preventDefault();
+            else if (this.model.presenting) {
+              event.preventDefault();
+              this.dispatch({ type: "TOGGLE_PRESENT" });
+            }
             return;
           }
           const command = map[event.key];
@@ -404,7 +440,7 @@
         (event) => {
           event.stopPropagation();
           this.root.focus({ preventScroll: true });
-          this.dispatch({ type: "TOGGLE_PAUSE" });
+          this.dispatch({ type: "PLAY_WITH_CONSENT" });
         },
         { signal },
       );
@@ -428,6 +464,14 @@
         { signal },
       );
       if (this.root.hasAttribute("data-ms-standalone")) this.root.focus({ preventScroll: true });
+      document.addEventListener(
+        "fullscreenchange",
+        () => {
+          if (this.model.presenting && document.fullscreenElement !== this.root)
+            this.dispatch({ type: "FULLSCREEN_EXITED" });
+        },
+        { signal },
+      );
       addEventListener("pagehide", () => this.destroy(), { once: true, signal });
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,10 @@ requires = ["hatchling", "hatch-fancy-pypi-readme"]
 
 [dependency-groups]
 browser-tests = [
-  {include-group = "tests-no-qt"},
   "playwright==1.62.0",
+  "pytest>=7.4.0",
+  "pytest-cov>=4.1.0",
+  "pytest-env>=0.8.2",
 ]
 dev = [
   {include-group = "docs"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,10 @@ build-backend = "hatchling.build"
 requires = ["hatchling", "hatch-fancy-pypi-readme"]
 
 [dependency-groups]
+browser-tests = [
+  {include-group = "tests-no-qt"},
+  "playwright==1.62.0",
+]
 dev = [
   {include-group = "docs"},
   {include-group = "tests"},

--- a/tests/player_core.test.cjs
+++ b/tests/player_core.test.cjs
@@ -98,9 +98,86 @@ test("reduced motion waits in the existing paused state for explicit playback", 
   assert.equal(model.resumeStatus, Core.Status.PLAYING_FORWARD);
   assert.equal(result.effects.length, 0);
 
-  result = apply(model, { type: "TOGGLE_PAUSE" });
+  result = apply(model, { type: "PLAY_WITH_CONSENT" });
+  assert.equal(result.model.animationOptIn, true);
   assert.equal(result.model.status, Core.Status.PLAYING_FORWARD);
   assert.deepEqual(result.effects, [{ type: "play", userGesture: true }]);
+
+  model = result.model;
+  result = apply(model, { type: "NEXT" });
+  model = apply(result.model, {
+    type: "HOLD_READY",
+    generation: result.model.generation,
+  }).model;
+  result = apply(model, { type: "NEXT" });
+  assert.equal(result.model.animationOptIn, true);
+});
+
+test("forward intent finishes unseen forward playback before advancing", () => {
+  let model = loadedForward();
+  let result = apply(model, { type: "NEXT" });
+  assert.equal(result.model.index, 0);
+  assert.equal(result.effects[0].type, "hold");
+  model = result.model;
+  result = apply(model, { type: "HOLD_READY", generation: model.generation });
+  model = result.model;
+  assert.equal(model.status, Core.Status.HELD_END);
+  result = apply(model, { type: "NEXT" });
+  assert.equal(result.effects[0].slideIndex, 1);
+
+  model = loadedForward();
+  model = apply(model, { type: "TOGGLE_PAUSE" }).model;
+  result = apply(model, { type: "NEXT" });
+  assert.equal(result.model.index, 0);
+  assert.equal(result.effects[0].type, "hold");
+});
+
+test("repeated back intent settles active reverse playback deterministically", () => {
+  let model = { ...loadedForward(1), status: Core.Status.HELD_END };
+  let result = apply(model, { type: "BACK" });
+  model = result.model;
+  result = apply(model, {
+    type: "LOAD_READY",
+    generation: model.generation,
+    playable: true,
+  });
+  model = result.model;
+  result = apply(model, { type: "PLAY_STARTED", generation: model.generation });
+  model = result.model;
+  result = apply(model, { type: "BACK" });
+  assert.equal(result.effects[0].type, "hold");
+  assert.equal(result.model.index, 1);
+  model = result.model;
+  result = apply(model, { type: "HOLD_READY", generation: model.generation });
+  assert.equal(result.model.index, 0);
+  assert.equal(result.model.status, Core.Status.HELD_END);
+});
+
+test("Present mode is model state and supplies durable animation consent", () => {
+  let model = Core.initial(slides.length);
+  let result = apply(model, { type: "BOOT" });
+  model = result.model;
+  result = apply(model, {
+    type: "LOAD_READY",
+    generation: model.generation,
+    playable: true,
+    requiresGesture: true,
+  });
+  model = result.model;
+  result = apply(model, { type: "TOGGLE_PRESENT" });
+  assert.equal(result.model.presenting, true);
+  assert.equal(result.model.animationOptIn, true);
+  assert.equal(result.model.status, Core.Status.PLAYING_FORWARD);
+  assert.deepEqual(result.effects, [
+    { type: "play", userGesture: true },
+    { type: "request-fullscreen" },
+    { type: "focus-player" },
+  ]);
+
+  model = result.model;
+  result = apply(model, { type: "FULLSCREEN_EXITED" });
+  assert.equal(result.model.presenting, false);
+  assert.deepEqual(result.effects, [{ type: "focus-player" }]);
 });
 
 test("first and last boundaries are quiet", () => {
@@ -116,6 +193,14 @@ test("stale completions and rapid next back next cannot win", () => {
   let model = loadedForward(1);
   let result = apply(model, { type: "BACK" });
   const stale = result.model.generation;
+  model = result.model;
+  result = apply(model, {
+    type: "LOAD_READY",
+    generation: model.generation,
+    playable: true,
+  });
+  model = result.model;
+  result = apply(model, { type: "PLAY_STARTED", generation: model.generation });
   model = result.model;
   result = apply(model, { type: "NEXT" });
   model = result.model;

--- a/tests/player_core.test.cjs
+++ b/tests/player_core.test.cjs
@@ -80,6 +80,27 @@ test("replay and pause resume preserve semantic role", () => {
   result = apply(result.model, { type: "REPLAY" });
   assert.equal(result.effects[0].seek, "start");
   assert.equal(result.effects[0].slideIndex, 0);
+  assert.equal(result.effects[0].userGesture, true);
+});
+
+test("reduced motion waits in the existing paused state for explicit playback", () => {
+  let model = Core.initial(slides.length);
+  let result = apply(model, { type: "BOOT" });
+  model = result.model;
+  result = apply(model, {
+    type: "LOAD_READY",
+    generation: model.generation,
+    playable: true,
+    requiresGesture: true,
+  });
+  model = result.model;
+  assert.equal(model.status, Core.Status.PAUSED);
+  assert.equal(model.resumeStatus, Core.Status.PLAYING_FORWARD);
+  assert.equal(result.effects.length, 0);
+
+  result = apply(model, { type: "TOGGLE_PAUSE" });
+  assert.equal(result.model.status, Core.Status.PLAYING_FORWARD);
+  assert.deepEqual(result.effects, [{ type: "play", userGesture: true }]);
 });
 
 test("first and last boundaries are quiet", () => {

--- a/tests/player_core.test.cjs
+++ b/tests/player_core.test.cjs
@@ -1,0 +1,125 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const Core = require("../manim_slides/html_player/player-core.js");
+
+const slides = [
+  { autoNext: false, loop: false },
+  { autoNext: false, loop: false },
+  { autoNext: true, loop: false },
+];
+
+function apply(model, event) {
+  return Core.transition(model, event, { slides });
+}
+
+function loadedForward(index = 0) {
+  let model = Core.initial(slides.length);
+  let result = apply(model, { type: "BOOT" });
+  model = result.model;
+  result = apply(model, { type: "LOAD_READY", generation: model.generation, playable: true });
+  model = result.model;
+  result = apply(model, { type: "PLAY_STARTED", generation: model.generation });
+  model = result.model;
+  if (index) {
+    result = apply(model, { type: "JUMP", index });
+    model = result.model;
+    result = apply(model, { type: "LOAD_READY", generation: model.generation, playable: false });
+    model = result.model;
+  }
+  return model;
+}
+
+test("normal forward, held, next, reverse, and direct jump transitions", () => {
+  let model = loadedForward();
+  assert.equal(model.status, Core.Status.PLAYING_FORWARD);
+  let result = apply(model, { type: "ENDED", generation: model.generation });
+  model = result.model;
+  assert.equal(model.status, Core.Status.HELD_END);
+  result = apply(model, { type: "NEXT" });
+  assert.equal(result.effects[0].slideIndex, 1);
+  model = result.model;
+  result = apply(model, { type: "LOAD_READY", generation: model.generation, playable: true });
+  model = result.model;
+  result = apply(model, { type: "PLAY_STARTED", generation: model.generation });
+  model = result.model;
+  result = apply(model, { type: "ENDED", generation: model.generation });
+  model = result.model;
+  result = apply(model, { type: "BACK" });
+  assert.equal(result.effects[0].role, "reverse");
+  assert.equal(result.effects[0].slideIndex, 1);
+  model = result.model;
+  result = apply(model, { type: "LOAD_READY", generation: model.generation, playable: true });
+  model = result.model;
+  result = apply(model, { type: "PLAY_STARTED", generation: model.generation });
+  model = result.model;
+  result = apply(model, { type: "ENDED", generation: model.generation });
+  assert.equal(result.model.index, 0);
+  assert.equal(result.model.status, Core.Status.HELD_END);
+  result = apply(result.model, { type: "JUMP", index: 2 });
+  assert.equal(result.effects[0].seek, "end");
+});
+
+test("partial reversal mapping and duration mismatch fallback are deterministic", () => {
+  assert.deepEqual(Core.mapReverseTime(2, 4, 4), { fallback: false, time: 2 });
+  assert.deepEqual(Core.mapReverseTime(2, 4, 7), { fallback: true, time: 0 });
+  const model = loadedForward(1);
+  const playing = { ...model, status: Core.Status.PLAYING_FORWARD };
+  const result = apply(playing, { type: "BACK" });
+  assert.equal(result.effects[0].seek, "mapped");
+  assert.equal(result.effects[0].mapFromActive, true);
+});
+
+test("replay and pause resume preserve semantic role", () => {
+  let model = loadedForward();
+  let result = apply(model, { type: "TOGGLE_PAUSE" });
+  model = result.model;
+  assert.equal(model.status, Core.Status.PAUSED);
+  assert.equal(model.resumeStatus, Core.Status.PLAYING_FORWARD);
+  result = apply(model, { type: "TOGGLE_PAUSE" });
+  assert.equal(result.model.status, Core.Status.PLAYING_FORWARD);
+  result = apply(result.model, { type: "REPLAY" });
+  assert.equal(result.effects[0].seek, "start");
+  assert.equal(result.effects[0].slideIndex, 0);
+});
+
+test("first and last boundaries are quiet", () => {
+  let model = loadedForward();
+  let result = apply({ ...model, status: Core.Status.HELD_END }, { type: "BACK" });
+  assert.equal(result.effects.length, 0);
+  model = loadedForward(2);
+  result = apply(model, { type: "NEXT" });
+  assert.equal(result.effects.length, 0);
+});
+
+test("stale completions and rapid next back next cannot win", () => {
+  let model = loadedForward(1);
+  let result = apply(model, { type: "BACK" });
+  const stale = result.model.generation;
+  model = result.model;
+  result = apply(model, { type: "NEXT" });
+  model = result.model;
+  result = apply(model, { type: "BACK" });
+  model = result.model;
+  result = apply(model, { type: "NEXT" });
+  model = result.model;
+  const ignored = apply(model, { type: "LOAD_READY", generation: stale, playable: true });
+  assert.strictEqual(ignored.model, model);
+  assert.ok(model.generation > stale);
+});
+
+test("loop, auto-next, error, and retry effects are explicit", () => {
+  let model = loadedForward(1);
+  model = { ...model, active: { role: "forward", settleIndex: 1, slideIndex: 1 } };
+  let result = Core.transition(model, { type: "ENDED", generation: model.generation }, {
+    slides: [slides[0], { autoNext: false, loop: true }, slides[2]],
+  });
+  assert.equal(result.effects[0].type, "replay-active");
+  model = loadedForward(1);
+  result = apply(model, { type: "NEXT" });
+  model = result.model;
+  const generation = model.generation;
+  result = apply(model, { type: "ERROR", generation, message: "decode failed" });
+  assert.equal(result.model.status, Core.Status.FAILED);
+  result = apply(result.model, { type: "RETRY" });
+  assert.equal(result.effects[0].type, "load");
+});

--- a/tests/test_html_player.py
+++ b/tests/test_html_player.py
@@ -1,0 +1,243 @@
+import base64
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import cast
+
+import pytest
+from bs4 import BeautifulSoup
+from click.testing import CliRunner
+from pydantic import ValidationError
+
+from manim_slides.__main__ import cli
+from manim_slides.config import PresentationConfig, SlideConfig, SlideType
+from manim_slides.convert import Converter, HtmlPlayer, RevealJS
+
+
+def read_manifest(output: Path) -> dict:
+    soup = BeautifulSoup(output.read_text(encoding="utf-8"), "html.parser")
+    node = soup.select_one("[data-ms-manifest]")
+    assert node is not None
+    return json.loads(node.text)
+
+
+def payloads(output: Path) -> dict[str, tuple[str, bytes]]:
+    soup = BeautifulSoup(output.read_text(encoding="utf-8"), "html.parser")
+    return {
+        cast(str, node["data-ms-asset"]): (
+            cast(str, node["data-mime"]),
+            base64.b64decode(node.text.strip(), validate=True),
+        )
+        for node in soup.select("script[data-ms-asset]")
+    }
+
+
+def test_converter_lookup() -> None:
+    assert Converter.from_string("html-player") is HtmlPlayer
+
+
+def test_cli_selection_and_show_config(slides_folder: Path) -> None:
+    runner = CliRunner()
+    shown = runner.invoke(cli, ["-S", "convert", "--to=html-player", "--show-config"])
+    assert shown.exit_code == 0
+    assert "one_file: False" in shown.output
+    assert "background_size: 'contain'" in shown.output
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "-S",
+                "convert",
+                "BasicSlide",
+                "player.html",
+                "--folder",
+                str(slides_folder),
+                "--to=html-player",
+                "--one-file",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert Path("player.html").is_file()
+        assert not Path("player_assets").exists()
+
+
+def test_custom_reveal_template_is_rejected() -> None:
+    with pytest.raises(ValidationError) as error:
+        HtmlPlayer.model_validate(
+            {"presentation_configs": [], "template": "revealjs.html"}
+        )
+    assert error.value.errors()[0]["loc"] == ("template",)
+
+
+def test_manifest_is_deterministic_for_multiple_scenes(
+    tmp_path: Path, presentation_config: PresentationConfig
+) -> None:
+    outputs = [tmp_path / "first.html", tmp_path / "second.html"]
+    for output in outputs:
+        HtmlPlayer(
+            presentation_configs=[presentation_config, presentation_config],
+            one_file=True,
+            title="A deterministic deck",
+        ).convert_to(output)
+    manifests = [read_manifest(output) for output in outputs]
+    assert manifests[0] == manifests[1]
+    assert len(manifests[0]["presentations"]) == 2
+    assert len(manifests[0]["slides"]) == 2 * len(presentation_config.slides)
+    assert manifests[0]["version"] == 1
+
+
+def test_asset_backed_copies_forward_reverse_and_local_runtime(
+    tmp_path: Path, presentation_config: PresentationConfig
+) -> None:
+    output = tmp_path / "deck.html"
+    HtmlPlayer(presentation_configs=[presentation_config]).convert_to(output)
+    manifest = read_manifest(output)
+    assets = tmp_path / "deck_assets"
+    assert assets.is_dir()
+    assert {"player-core.js", "player.js", "player.css"} <= {
+        path.name for path in assets.iterdir()
+    }
+    references = {
+        slide[role]["url"] for slide in manifest["slides"] for role in ("forward", "reverse")
+    }
+    assert all(url.startswith("deck_assets/media-") for url in references)
+    assert all((tmp_path / Path(url)).is_file() for url in references)
+    assert all(slide["forward"]["id"] != slide["reverse"]["id"] for slide in manifest["slides"])
+    content = output.read_text(encoding="utf-8")
+    assert "https://" not in content
+    assert "http://" not in content
+
+
+def test_collision_safe_asset_names(
+    tmp_path: Path, presentation_config: PresentationConfig
+) -> None:
+    dirs = [tmp_path / "one", tmp_path / "two"]
+    for directory in dirs:
+        directory.mkdir()
+    sources = [presentation_config.slides[0].file, presentation_config.slides[-1].file]
+    same_names = []
+    for directory, source in zip(dirs, sources, strict=True):
+        destination = directory / "clip.mp4"
+        shutil.copyfile(source, destination)
+        same_names.append(destination)
+    slides = [
+        SlideConfig(file=path, rev_file=path, type=SlideType.Video)
+        for path in same_names
+    ]
+    output = tmp_path / "collision.html"
+    HtmlPlayer(presentation_configs=[PresentationConfig(slides=slides)]).convert_to(output)
+    names = [slide["forward"]["url"] for slide in read_manifest(output)["slides"]]
+    assert len(set(names)) == 2
+    assert all("clip.mp4" not in name for name in names)
+
+
+def test_portable_payloads_are_unique_exact_and_inert(
+    tmp_path: Path, presentation_config: PresentationConfig
+) -> None:
+    output = tmp_path / "portable.html"
+    HtmlPlayer(presentation_configs=[presentation_config], one_file=True).convert_to(output)
+    manifest = read_manifest(output)
+    embedded = payloads(output)
+    referenced = {
+        slide[role]["id"] for slide in manifest["slides"] for role in ("forward", "reverse")
+    }
+    assert set(embedded) == referenced
+    assert all(mime == "video/mp4" for mime, _ in embedded.values())
+    expected = {
+        hashlib.sha256(path.read_bytes()).hexdigest()[:16]: path.read_bytes()
+        for slide in presentation_config.slides
+        for path in (slide.file, slide.rev_file)
+    }
+    for asset_id, (_, data) in embedded.items():
+        assert data == expected[asset_id.removeprefix("asset-")]
+    content = output.read_text(encoding="utf-8")
+    assert "data:video" not in content
+    assert "https://" not in content
+    assert "http://" not in content
+    assert "deck_assets" not in content
+
+
+def test_metadata_and_hostile_text_are_safe(
+    tmp_path: Path, presentation_config: PresentationConfig
+) -> None:
+    hostile = '</script><script>globalThis.hostile = "yes"</script>&\u2028'
+    slide = presentation_config.slides[0].model_copy(
+        update={
+            "auto_next": True,
+            "direction": "vertical",
+            "loop": True,
+            "notes": hostile,
+            "playback_rate": 1.5,
+            "reversed_playback_rate": 0.75,
+        }
+    )
+    config = PresentationConfig(
+        slides=[slide],
+        resolution=(640, 360),
+        background_color="#123456",
+    )
+    output = tmp_path / "hostile.html"
+    HtmlPlayer(
+        presentation_configs=[config], one_file=True, title=hostile
+    ).convert_to(output)
+    manifest = read_manifest(output)
+    got = manifest["slides"][0]
+    assert got["autoNext"] and got["loop"]
+    assert got["direction"] == "vertical"
+    assert got["notes"] == hostile
+    assert got["playbackRate"] == 1.5
+    assert got["reversedPlaybackRate"] == 0.75
+    assert got["resolution"] == [640, 360]
+    content = output.read_text(encoding="utf-8")
+    assert "</script><script>globalThis.hostile" not in content
+    assert "&lt;/script&gt;&lt;script&gt;globalThis.hostile" in content
+    assert "\\u003c/script\\u003e" in content
+
+
+def test_image_slide_uses_one_first_class_asset(tmp_path: Path) -> None:
+    image = tmp_path / "still.png"
+    from PIL import Image
+
+    Image.new("RGB", (8, 8), "purple").save(image)
+    slide = SlideConfig(file=image, rev_file=image, type=SlideType.Image, notes="Still")
+    output = tmp_path / "image.html"
+    HtmlPlayer(
+        presentation_configs=[PresentationConfig(slides=[slide])], one_file=True
+    ).convert_to(output)
+    manifest = read_manifest(output)
+    got = manifest["slides"][0]
+    assert got["type"] == "image"
+    assert got["forward"] == got["reverse"]
+    assert len(payloads(output)) == 1
+    assert next(iter(payloads(output).values()))[0] == "image/png"
+
+
+def test_missing_and_corrupt_assets_fail_with_slide_and_role(tmp_path: Path) -> None:
+    corrupt = tmp_path / "corrupt.mp4"
+    corrupt.write_bytes(b"not a video")
+    slide = SlideConfig(file=corrupt, rev_file=corrupt)
+    with pytest.raises(ValueError, match=r"scene-1-slide-1.*forward.*corrupt\.mp4"):
+        HtmlPlayer(
+            presentation_configs=[PresentationConfig(slides=[slide])]
+        ).convert_to(tmp_path / "corrupt.html")
+
+    missing = tmp_path / "missing.mp4"
+    shutil.copyfile(Path("tests/data/video.mp4"), missing)
+    missing_slide = SlideConfig(file=missing, rev_file=missing)
+    missing.unlink()
+    with pytest.raises(ValueError, match=r"scene-1-slide-1.*forward.*missing\.mp4"):
+        HtmlPlayer(
+            presentation_configs=[PresentationConfig(slides=[missing_slide])]
+        ).convert_to(tmp_path / "missing.html")
+
+
+def test_revealjs_compatibility_still_copies_only_forward_assets(
+    tmp_path: Path, presentation_config: PresentationConfig
+) -> None:
+    output = tmp_path / "reveal.html"
+    RevealJS(presentation_configs=[presentation_config]).convert_to(output)
+    assert len(list((tmp_path / "reveal_assets").iterdir())) == len(
+        presentation_config.slides
+    )

--- a/tests/test_html_player.py
+++ b/tests/test_html_player.py
@@ -100,11 +100,15 @@ def test_asset_backed_copies_forward_reverse_and_local_runtime(
         path.name for path in assets.iterdir()
     }
     references = {
-        slide[role]["url"] for slide in manifest["slides"] for role in ("forward", "reverse")
+        slide[role]["url"]
+        for slide in manifest["slides"]
+        for role in ("forward", "reverse")
     }
     assert all(url.startswith("deck_assets/media-") for url in references)
     assert all((tmp_path / Path(url)).is_file() for url in references)
-    assert all(slide["forward"]["id"] != slide["reverse"]["id"] for slide in manifest["slides"])
+    assert all(
+        slide["forward"]["id"] != slide["reverse"]["id"] for slide in manifest["slides"]
+    )
     content = output.read_text(encoding="utf-8")
     assert "https://" not in content
     assert "http://" not in content
@@ -127,7 +131,9 @@ def test_collision_safe_asset_names(
         for path in same_names
     ]
     output = tmp_path / "collision.html"
-    HtmlPlayer(presentation_configs=[PresentationConfig(slides=slides)]).convert_to(output)
+    HtmlPlayer(presentation_configs=[PresentationConfig(slides=slides)]).convert_to(
+        output
+    )
     names = [slide["forward"]["url"] for slide in read_manifest(output)["slides"]]
     assert len(set(names)) == 2
     assert all("clip.mp4" not in name for name in names)
@@ -137,11 +143,15 @@ def test_portable_payloads_are_unique_exact_and_inert(
     tmp_path: Path, presentation_config: PresentationConfig
 ) -> None:
     output = tmp_path / "portable.html"
-    HtmlPlayer(presentation_configs=[presentation_config], one_file=True).convert_to(output)
+    HtmlPlayer(presentation_configs=[presentation_config], one_file=True).convert_to(
+        output
+    )
     manifest = read_manifest(output)
     embedded = payloads(output)
     referenced = {
-        slide[role]["id"] for slide in manifest["slides"] for role in ("forward", "reverse")
+        slide[role]["id"]
+        for slide in manifest["slides"]
+        for role in ("forward", "reverse")
     }
     assert set(embedded) == referenced
     assert all(mime == "video/mp4" for mime, _ in embedded.values())
@@ -179,9 +189,9 @@ def test_metadata_and_hostile_text_are_safe(
         background_color="#123456",
     )
     output = tmp_path / "hostile.html"
-    HtmlPlayer(
-        presentation_configs=[config], one_file=True, title=hostile
-    ).convert_to(output)
+    HtmlPlayer(presentation_configs=[config], one_file=True, title=hostile).convert_to(
+        output
+    )
     manifest = read_manifest(output)
     got = manifest["slides"][0]
     assert got["autoNext"] and got["loop"]

--- a/tests/test_html_player_browser.py
+++ b/tests/test_html_player_browser.py
@@ -1,0 +1,369 @@
+import io
+import hashlib
+import os
+from pathlib import Path
+
+import av
+import numpy as np
+import pytest
+from PIL import Image
+
+from manim_slides.config import PresentationConfig, SlideConfig
+from manim_slides.convert import HtmlPlayer
+
+playwright = pytest.importorskip("playwright.sync_api")
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MANIM_SLIDES_BROWSER_TESTS") != "1",
+    reason="set MANIM_SLIDES_BROWSER_TESTS=1 to run real-browser tests",
+)
+
+
+def make_video(path: Path, start: tuple[int, int, int], end: tuple[int, int, int]) -> None:
+    container = av.open(str(path), "w")
+    stream = container.add_stream("libx264", rate=15)
+    stream.width = 160
+    stream.height = 90
+    stream.pix_fmt = "yuv420p"
+    stream.options = {"preset": "ultrafast", "crf": "18"}
+    for index in range(15):
+        ratio = index / 14
+        color = np.array(
+            [round(a + (b - a) * ratio) for a, b in zip(start, end, strict=True)],
+            dtype=np.uint8,
+        )
+        pixels = np.empty((90, 160, 3), dtype=np.uint8)
+        pixels[:] = color
+        frame = av.VideoFrame.from_ndarray(pixels, format="rgb24")
+        for packet in stream.encode(frame):
+            container.mux(packet)
+    for packet in stream.encode():
+        container.mux(packet)
+    container.close()
+
+
+@pytest.fixture
+def color_config(tmp_path: Path) -> PresentationConfig:
+    red, green, blue = (220, 20, 20), (20, 210, 20), (20, 20, 220)
+    paths = {}
+    for name, start, end in (
+        ("zero-forward", red, green),
+        ("zero-reverse", green, red),
+        ("one-forward", green, blue),
+        ("one-reverse", blue, green),
+    ):
+        path = tmp_path / f"{name}.mp4"
+        make_video(path, start, end)
+        paths[name] = path
+    return PresentationConfig(
+        slides=[
+            SlideConfig(
+                file=paths["zero-forward"],
+                rev_file=paths["zero-reverse"],
+                notes='<img src=x onerror="globalThis.notesExecuted=true">Safe note',
+            ),
+            SlideConfig(
+                file=paths["one-forward"],
+                rev_file=paths["one-reverse"],
+                direction="vertical",
+                notes="Second note",
+            ),
+        ],
+        resolution=(160, 90),
+        background_color="black",
+    )
+
+
+@pytest.fixture(scope="module")
+def browser():
+    with playwright.sync_playwright() as instance:
+        browser = instance.chromium.launch()
+        yield browser
+        browser.close()
+
+
+def open_portable(browser, output: Path, **context_options):
+    context = browser.new_context(**context_options)
+    context.route("http://**", lambda route: route.abort())
+    context.route("https://**", lambda route: route.abort())
+    page = context.new_page()
+    requests = []
+    page.on("request", lambda request: requests.append(request.url))
+    page.goto(output.resolve().as_uri())
+    return context, page, requests
+
+
+def wait_held(page, index: int) -> None:
+    page.locator("[data-ms-player]").wait_for(state="visible")
+    page.wait_for_function(
+        "!['loading', 'transitioning', 'ready-at-start'].includes("
+        "document.querySelector('[data-ms-player]').dataset.state)",
+        timeout=10_000,
+    )
+    if page.locator("[data-ms-player]").get_attribute("data-state") == "paused":
+        page.locator("[data-ms-gesture]").click()
+    page.wait_for_function(
+        "([index]) => { const p = document.querySelector('[data-ms-player]'); "
+        "return p.dataset.state === 'held-at-end' && Number(p.dataset.slideIndex) === index; }",
+        arg=[index],
+        timeout=10_000,
+    )
+
+
+def center_rgb(page) -> tuple[int, int, int]:
+    screenshot = page.locator("[data-ms-stage]").screenshot()
+    image = Image.open(io.BytesIO(screenshot)).convert("RGB")
+    pixel = image.getpixel((image.width // 2, image.height // 2))
+    assert isinstance(pixel, tuple)
+    return int(pixel[0]), int(pixel[1]), int(pixel[2])
+
+
+def test_file_portable_navigation_reverse_pixels_and_cleanup(
+    browser, tmp_path: Path, color_config: PresentationConfig
+) -> None:
+    output = tmp_path / "portable.html"
+    HtmlPlayer(presentation_configs=[color_config], one_file=True).convert_to(output)
+    context, page, requests = open_portable(
+        browser, output, viewport={"width": 800, "height": 450}
+    )
+    wait_held(page, 0)
+    page.keyboard.press("ArrowRight")
+    wait_held(page, 1)
+    assert center_rgb(page)[2] > 150
+
+    page.keyboard.press("ArrowLeft")
+    samples = []
+    for _ in range(8):
+        page.wait_for_timeout(70)
+        samples.append(center_rgb(page))
+    wait_held(page, 0)
+    assert all(red < 90 for red, _green, _blue in samples)
+    final = center_rgb(page)
+    assert final[1] > 150 and final[0] < 90 and final[2] < 90
+    assert all(not url.startswith(("http://", "https://")) for url in requests)
+
+    assert (
+        page.evaluate(
+            "document.querySelector('[data-ms-player]').manimSlidesPlayer.assetStore.urls.size"
+        )
+        > 0
+    )
+    page.evaluate("document.querySelector('[data-ms-player]').manimSlidesPlayer.destroy()")
+    assert (
+        page.evaluate(
+            "document.querySelector('[data-ms-player]').manimSlidesPlayer.assetStore.urls.size"
+        )
+        == 0
+    )
+    context.close()
+
+
+def test_keyboard_click_notes_focus_and_rapid_input(
+    browser, tmp_path: Path, color_config: PresentationConfig
+) -> None:
+    output = tmp_path / "inputs.html"
+    HtmlPlayer(presentation_configs=[color_config], one_file=True).convert_to(output)
+    text = output.read_text(encoding="utf-8").replace(
+        '<main class="manim-slides-player" data-ms-player data-ms-standalone',
+        '<input id="host-input" aria-label="Host input">\n'
+        '<main class="manim-slides-player" data-ms-player',
+    )
+    output.write_text(text, encoding="utf-8")
+    context, page, _requests = open_portable(browser, output)
+    wait_held(page, 0)
+
+    page.locator("#host-input").focus()
+    page.keyboard.press("ArrowRight")
+    assert page.locator("[data-ms-player]").get_attribute("data-slide-index") == "0"
+    page.locator("[data-ms-player]").focus()
+    page.keyboard.press("Space")
+    wait_held(page, 1)
+    page.keyboard.press("PageUp")
+    wait_held(page, 0)
+    page.keyboard.press("PageDown")
+    wait_held(page, 1)
+    page.keyboard.press("ArrowLeft")
+    wait_held(page, 0)
+
+    page.locator("[data-command=notes]").click()
+    assert "Safe note" in page.locator("[data-ms-notes-text]").text_content()
+    assert page.evaluate("globalThis.notesExecuted") is None
+    page.locator("[data-command=notes]").click()
+
+    page.keyboard.press("o")
+    assert page.locator("[data-ms-overview]").is_visible()
+    page.locator("[data-ms-overview-list] button").nth(1).click()
+    wait_held(page, 1)
+    page.keyboard.press("ArrowLeft")
+    wait_held(page, 0)
+    page.keyboard.press("?")
+    assert page.locator("[data-ms-help]").is_visible()
+    page.keyboard.press("Escape")
+    assert not page.locator("[data-ms-help]").is_visible()
+
+    page.locator("[data-ms-stage]").click(position={"x": 300, "y": 180})
+    page.keyboard.press("ArrowLeft")
+    page.keyboard.press("ArrowRight")
+    page.keyboard.press("ArrowLeft")
+    page.keyboard.press("ArrowRight")
+    page.wait_for_timeout(1400)
+    assert page.locator("[data-ms-player]").get_attribute("data-state") != "failed"
+    context.close()
+
+
+def test_mobile_swipe_resize_and_autoplay_recovery(
+    browser, tmp_path: Path, color_config: PresentationConfig
+) -> None:
+    output = tmp_path / "mobile.html"
+    HtmlPlayer(presentation_configs=[color_config], one_file=True).convert_to(output)
+    context = browser.new_context(
+        viewport={"width": 390, "height": 844}, has_touch=True, is_mobile=True
+    )
+    page = context.new_page()
+    page.add_init_script(
+        """
+        const nativePlay = HTMLMediaElement.prototype.play;
+        let rejected = false;
+        HTMLMediaElement.prototype.play = function () {
+          if (!rejected) {
+            rejected = true;
+            return Promise.reject(new DOMException('gesture required', 'NotAllowedError'));
+          }
+          return nativePlay.call(this);
+        };
+        """
+    )
+    page.goto(output.resolve().as_uri())
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]').dataset.state === 'paused'"
+    )
+    assert page.locator("[data-ms-gesture]").is_visible()
+    page.locator("[data-ms-gesture]").click()
+    wait_held(page, 0)
+
+    stage = page.locator("[data-ms-stage]")
+    stage.dispatch_event(
+        "pointerdown",
+        {
+            "pointerId": 1,
+            "pointerType": "touch",
+            "isPrimary": True,
+            "button": 0,
+            "clientX": 330,
+            "clientY": 400,
+        },
+    )
+    stage.dispatch_event(
+        "pointermove",
+        {
+            "pointerId": 1,
+            "pointerType": "touch",
+            "isPrimary": True,
+            "clientX": 80,
+            "clientY": 400,
+        },
+    )
+    stage.dispatch_event(
+        "pointerup",
+        {
+            "pointerId": 1,
+            "pointerType": "touch",
+            "isPrimary": True,
+            "button": 0,
+            "clientX": 80,
+            "clientY": 400,
+        },
+    )
+    wait_held(page, 1)
+    page.set_viewport_size({"width": 844, "height": 390})
+    assert page.locator("[data-ms-player]").bounding_box()["width"] == pytest.approx(
+        844, abs=1
+    )
+
+    stage.dispatch_event(
+        "pointerdown",
+        {
+            "pointerId": 2,
+            "pointerType": "touch",
+            "isPrimary": True,
+            "button": 0,
+            "clientX": 400,
+            "clientY": 80,
+        },
+    )
+    stage.dispatch_event(
+        "pointermove",
+        {
+            "pointerId": 2,
+            "pointerType": "touch",
+            "isPrimary": True,
+            "clientX": 400,
+            "clientY": 300,
+        },
+    )
+    stage.dispatch_event(
+        "pointerup",
+        {
+            "pointerId": 2,
+            "pointerType": "touch",
+            "isPrimary": True,
+            "button": 0,
+            "clientX": 400,
+            "clientY": 300,
+        },
+    )
+    wait_held(page, 0)
+    context.close()
+
+
+def test_loop_auto_next_pause_replay_and_error_state(
+    browser, tmp_path: Path, color_config: PresentationConfig
+) -> None:
+    slides = [
+        color_config.slides[0].model_copy(update={"auto_next": True}),
+        color_config.slides[1].model_copy(update={"loop": True}),
+    ]
+    output = tmp_path / "metadata.html"
+    HtmlPlayer(
+        presentation_configs=[PresentationConfig(slides=slides, resolution=(160, 90))]
+    ).convert_to(output)
+    context, page, _requests = open_portable(browser, output)
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]').dataset.state === 'paused'",
+        timeout=10_000,
+    )
+    page.locator("[data-ms-gesture]").click()
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]').dataset.slideIndex === '1'",
+        timeout=10_000,
+    )
+    page.wait_for_timeout(1200)
+    assert (
+        page.locator("[data-ms-player]").get_attribute("data-state")
+        == "playing-forward"
+    )
+    page.locator("[data-command=pause]").click()
+    assert page.locator("[data-ms-player]").get_attribute("data-state") == "paused"
+    page.locator("[data-command=pause]").click()
+    page.locator("[data-command=replay]").click()
+    assert page.locator("[data-ms-player]").get_attribute("data-state") in {
+        "transitioning",
+        "playing-forward",
+        "ready-at-start",
+    }
+    context.close()
+
+    broken = tmp_path / "broken.html"
+    HtmlPlayer(presentation_configs=[color_config]).convert_to(broken)
+    digest = hashlib.sha256(color_config.slides[0].file.read_bytes()).hexdigest()[:16]
+    asset = next((tmp_path / "broken_assets").glob(f"media-{digest}.*"))
+    asset.unlink()
+    context, page, _requests = open_portable(browser, broken)
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]').dataset.state === 'failed'",
+        timeout=10_000,
+    )
+    assert "Slide 1 forward asset" in page.locator(
+        "[data-ms-error-message]"
+    ).text_content()
+    context.close()

--- a/tests/test_html_player_browser.py
+++ b/tests/test_html_player_browser.py
@@ -1,5 +1,5 @@
-import io
 import hashlib
+import io
 import os
 from pathlib import Path
 
@@ -19,7 +19,9 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def make_video(path: Path, start: tuple[int, int, int], end: tuple[int, int, int]) -> None:
+def make_video(
+    path: Path, start: tuple[int, int, int], end: tuple[int, int, int]
+) -> None:
     container = av.open(str(path), "w")
     stream = container.add_stream("libx264", rate=15)
     stream.width = 160
@@ -34,6 +36,27 @@ def make_video(path: Path, start: tuple[int, int, int], end: tuple[int, int, int
         )
         pixels = np.empty((90, 160, 3), dtype=np.uint8)
         pixels[:] = color
+        frame = av.VideoFrame.from_ndarray(pixels, format="rgb24")
+        for packet in stream.encode(frame):
+            container.mux(packet)
+    for packet in stream.encode():
+        container.mux(packet)
+    container.close()
+
+
+def make_motion_video(path: Path, *, reverse: bool = False) -> None:
+    container = av.open(str(path), "w")
+    stream = container.add_stream("libx264", rate=15)
+    stream.width = 160
+    stream.height = 90
+    stream.pix_fmt = "yuv420p"
+    stream.options = {"preset": "ultrafast", "crf": "18"}
+    for index in range(30):
+        position = 29 - index if reverse else index
+        left = round(8 + 134 * position / 29)
+        pixels = np.zeros((90, 160, 3), dtype=np.uint8)
+        pixels[44:46, 8:152] = (40, 100, 220)
+        pixels[35:55, left : left + 18] = (230, 40, 40)
         frame = av.VideoFrame.from_ndarray(pixels, format="rgb24")
         for packet in stream.encode(frame):
             container.mux(packet)
@@ -68,6 +91,22 @@ def color_config(tmp_path: Path) -> PresentationConfig:
                 direction="vertical",
                 notes="Second note",
             ),
+        ],
+        resolution=(160, 90),
+        background_color="black",
+    )
+
+
+@pytest.fixture
+def motion_config(tmp_path: Path) -> PresentationConfig:
+    forward = tmp_path / "motion-forward.mp4"
+    reverse = tmp_path / "motion-reverse.mp4"
+    make_motion_video(forward)
+    make_motion_video(reverse, reverse=True)
+    return PresentationConfig(
+        slides=[
+            SlideConfig(file=forward, rev_file=reverse),
+            SlideConfig(file=forward, rev_file=reverse),
         ],
         resolution=(160, 90),
         background_color="black",
@@ -118,6 +157,122 @@ def center_rgb(page) -> tuple[int, int, int]:
     return int(pixel[0]), int(pixel[1]), int(pixel[2])
 
 
+def active_video_telemetry(page) -> dict[str, object]:
+    value = page.evaluate(
+        """() => {
+          const player = document.querySelector('[data-ms-player]');
+          const video = player.manimSlidesPlayer.currentVideo();
+          return {
+            attributeSrc: video.getAttribute('src'),
+            src: video.src,
+            currentSrc: video.currentSrc,
+            currentTime: video.currentTime,
+            duration: video.duration,
+            paused: video.paused,
+          };
+        }"""
+    )
+    assert isinstance(value, dict)
+    return value
+
+
+def wait_playing_and_assert_time_advances(page, role: str) -> None:
+    page.wait_for_function(
+        "role => document.querySelector('[data-ms-player]').dataset.state === role",
+        arg=role,
+        timeout=10_000,
+    )
+    start = active_video_telemetry(page)["currentTime"]
+    assert isinstance(start, (int, float))
+    page.wait_for_function(
+        "start => document.querySelector('[data-ms-player]').manimSlidesPlayer"
+        ".currentVideo().currentTime > start + 0.12",
+        arg=start,
+        timeout=3_000,
+    )
+
+
+def assert_blob_source_is_not_document(page, output: Path) -> None:
+    telemetry = active_video_telemetry(page)
+    assert isinstance(telemetry["attributeSrc"], str)
+    assert telemetry["attributeSrc"].startswith("blob:")
+    assert telemetry["src"] == telemetry["currentSrc"]
+    assert telemetry["src"] != output.resolve().as_uri()
+    assert page.evaluate(
+        "[...document.querySelectorAll('video')].every(video => video.src !== location.href)"
+    )
+
+
+def test_file_portable_motion_preferences_and_explicit_playback(
+    browser, tmp_path: Path, motion_config: PresentationConfig
+) -> None:
+    output = tmp_path / "motion.html"
+    HtmlPlayer(presentation_configs=[motion_config], one_file=True).convert_to(output)
+
+    context, page, requests = open_portable(
+        browser, output, reduced_motion="no-preference"
+    )
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]')?.manimSlidesPlayer"
+        "?.currentVideo()?.currentSrc"
+    )
+    assert_blob_source_is_not_document(page, output)
+    if page.locator("[data-ms-player]").get_attribute("data-state") == "paused":
+        page.locator("[data-ms-gesture]").click()
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    wait_held(page, 0)
+
+    page.locator("nav [data-command=next]").click()
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    wait_held(page, 1)
+    page.locator("nav [data-command=back]").click()
+    wait_playing_and_assert_time_advances(page, "playing-reverse")
+    wait_held(page, 0)
+    page.locator("[data-command=replay]").click()
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    assert all(not url.startswith(("http://", "https://")) for url in requests)
+    context.close()
+
+    context, page, requests = open_portable(browser, output, reduced_motion="reduce")
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]')?.dataset.state === 'paused'"
+    )
+    assert page.evaluate("matchMedia('(prefers-reduced-motion: reduce)').matches")
+    assert_blob_source_is_not_document(page, output)
+    before = active_video_telemetry(page)["currentTime"]
+    page.wait_for_timeout(300)
+    after = active_video_telemetry(page)["currentTime"]
+    assert isinstance(before, (int, float))
+    assert isinstance(after, (int, float))
+    assert before < 0.05
+    assert after == pytest.approx(before, abs=0.02)
+    assert page.locator("[data-ms-gesture]").is_visible()
+    assert page.locator("[data-ms-gesture]").text_content() == "Play animation"
+    page.locator("[data-ms-gesture]").click()
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    wait_held(page, 0)
+
+    page.locator("nav [data-command=next]").click()
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]').dataset.state === 'paused' && "
+        "document.querySelector('[data-ms-player]').dataset.slideIndex === '1'"
+    )
+    page.locator("[data-ms-gesture]").click()
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    wait_held(page, 1)
+    page.locator("nav [data-command=back]").click()
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]').dataset.state === 'paused'"
+    )
+    page.locator("[data-ms-gesture]").click()
+    wait_playing_and_assert_time_advances(page, "playing-reverse")
+    wait_held(page, 0)
+    page.locator("[data-command=replay]").click()
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    assert all(not url.startswith(("http://", "https://")) for url in requests)
+    context.close()
+
+
 def test_file_portable_navigation_reverse_pixels_and_cleanup(
     browser, tmp_path: Path, color_config: PresentationConfig
 ) -> None:
@@ -148,7 +303,9 @@ def test_file_portable_navigation_reverse_pixels_and_cleanup(
         )
         > 0
     )
-    page.evaluate("document.querySelector('[data-ms-player]').manimSlidesPlayer.destroy()")
+    page.evaluate(
+        "document.querySelector('[data-ms-player]').manimSlidesPlayer.destroy()"
+    )
     assert (
         page.evaluate(
             "document.querySelector('[data-ms-player]').manimSlidesPlayer.assetStore.urls.size"
@@ -363,7 +520,8 @@ def test_loop_auto_next_pause_replay_and_error_state(
         "document.querySelector('[data-ms-player]').dataset.state === 'failed'",
         timeout=10_000,
     )
-    assert "Slide 1 forward asset" in page.locator(
-        "[data-ms-error-message]"
-    ).text_content()
+    assert (
+        "Slide 1 forward asset"
+        in page.locator("[data-ms-error-message]").text_content()
+    )
     context.close()

--- a/tests/test_html_player_browser.py
+++ b/tests/test_html_player_browser.py
@@ -116,7 +116,9 @@ def motion_config(tmp_path: Path) -> PresentationConfig:
 @pytest.fixture(scope="module")
 def browser():
     with playwright.sync_playwright() as instance:
-        browser = instance.chromium.launch()
+        browser = instance.chromium.launch(
+            args=["--autoplay-policy=no-user-gesture-required"]
+        )
         yield browser
         browser.close()
 
@@ -203,6 +205,28 @@ def assert_blob_source_is_not_document(page, output: Path) -> None:
     )
 
 
+def swipe(
+    page,
+    *,
+    pointer_id: int,
+    start: tuple[int, int],
+    end: tuple[int, int],
+) -> None:
+    stage = page.locator("[data-ms-stage]")
+    common = {"pointerId": pointer_id, "pointerType": "touch", "isPrimary": True}
+    stage.dispatch_event(
+        "pointerdown",
+        {**common, "button": 0, "clientX": start[0], "clientY": start[1]},
+    )
+    stage.dispatch_event(
+        "pointermove", {**common, "clientX": end[0], "clientY": end[1]}
+    )
+    stage.dispatch_event(
+        "pointerup",
+        {**common, "button": 0, "clientX": end[0], "clientY": end[1]},
+    )
+
+
 def test_file_portable_motion_preferences_and_explicit_playback(
     browser, tmp_path: Path, motion_config: PresentationConfig
 ) -> None:
@@ -217,16 +241,16 @@ def test_file_portable_motion_preferences_and_explicit_playback(
         "?.currentVideo()?.currentSrc"
     )
     assert_blob_source_is_not_document(page, output)
-    if page.locator("[data-ms-player]").get_attribute("data-state") == "paused":
-        page.locator("[data-ms-gesture]").click()
     wait_playing_and_assert_time_advances(page, "playing-forward")
+    page.keyboard.press("Space")
     wait_held(page, 0)
 
-    page.locator("nav [data-command=next]").click()
+    page.keyboard.press("Space")
     wait_playing_and_assert_time_advances(page, "playing-forward")
     wait_held(page, 1)
     page.locator("nav [data-command=back]").click()
     wait_playing_and_assert_time_advances(page, "playing-reverse")
+    page.locator("nav [data-command=back]").click()
     wait_held(page, 0)
     page.locator("[data-command=replay]").click()
     wait_playing_and_assert_time_advances(page, "playing-forward")
@@ -249,27 +273,146 @@ def test_file_portable_motion_preferences_and_explicit_playback(
     assert page.locator("[data-ms-gesture]").is_visible()
     assert page.locator("[data-ms-gesture]").text_content() == "Play animation"
     page.locator("[data-ms-gesture]").click()
+    assert (
+        page.locator("[data-ms-player]").get_attribute("data-animation-opt-in")
+        == "true"
+    )
     wait_playing_and_assert_time_advances(page, "playing-forward")
-    wait_held(page, 0)
 
     page.locator("nav [data-command=next]").click()
-    page.wait_for_function(
-        "document.querySelector('[data-ms-player]').dataset.state === 'paused' && "
-        "document.querySelector('[data-ms-player]').dataset.slideIndex === '1'"
-    )
-    page.locator("[data-ms-gesture]").click()
+    wait_held(page, 0)
+    page.locator("nav [data-command=next]").click()
     wait_playing_and_assert_time_advances(page, "playing-forward")
+    assert not page.locator("[data-ms-gesture]").is_visible()
     wait_held(page, 1)
     page.locator("nav [data-command=back]").click()
-    page.wait_for_function(
-        "document.querySelector('[data-ms-player]').dataset.state === 'paused'"
-    )
-    page.locator("[data-ms-gesture]").click()
     wait_playing_and_assert_time_advances(page, "playing-reverse")
+    page.locator("nav [data-command=back]").click()
     wait_held(page, 0)
     page.locator("[data-command=replay]").click()
     wait_playing_and_assert_time_advances(page, "playing-forward")
     assert all(not url.startswith(("http://", "https://")) for url in requests)
+    context.close()
+
+
+def test_forward_click_and_visible_next_are_two_step_intents(
+    browser, tmp_path: Path, motion_config: PresentationConfig
+) -> None:
+    output = tmp_path / "forward-intents.html"
+    HtmlPlayer(presentation_configs=[motion_config], one_file=True).convert_to(output)
+    context, page, requests = open_portable(browser, output)
+
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    page.locator("nav [data-command=next]").click()
+    wait_held(page, 0)
+    page.locator("nav [data-command=next]").click()
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    wait_held(page, 1)
+
+    page.keyboard.press("ArrowLeft")
+    wait_held(page, 0)
+    page.keyboard.press("r")
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    page.locator("[data-ms-stage]").click(position={"x": 300, "y": 180})
+    wait_held(page, 0)
+    page.locator("[data-ms-stage]").click(position={"x": 300, "y": 180})
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    assert page.locator("[data-ms-player]").get_attribute("data-slide-index") == "1"
+    assert all(not url.startswith(("http://", "https://")) for url in requests)
+    context.close()
+
+
+def test_present_mode_consent_chrome_overlays_and_fullscreen_rejection(
+    browser, tmp_path: Path, motion_config: PresentationConfig
+) -> None:
+    output = tmp_path / "present-rejected.html"
+    HtmlPlayer(presentation_configs=[motion_config], one_file=True).convert_to(output)
+    context = browser.new_context(reduced_motion="reduce")
+    context.route("http://**", lambda route: route.abort())
+    context.route("https://**", lambda route: route.abort())
+    page = context.new_page()
+    requests = []
+    page.on("request", lambda request: requests.append(request.url))
+    page.add_init_script(
+        """
+        Object.defineProperty(Element.prototype, 'requestFullscreen', {
+          configurable: true,
+          value() { return Promise.reject(new DOMException('denied', 'NotAllowedError')); },
+        });
+        """
+    )
+    page.goto(output.resolve().as_uri())
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]').dataset.state === 'paused'"
+    )
+
+    page.get_by_role("button", name="Enter presentation mode").click()
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    player = page.locator("[data-ms-player]")
+    assert player.get_attribute("data-presenting") == "true"
+    assert player.get_attribute("data-animation-opt-in") == "true"
+    assert player.evaluate("node => node === document.activeElement")
+    for selector in (".ms-controls", ".ms-position", ".ms-progress"):
+        assert (
+            page.locator(selector).evaluate("node => getComputedStyle(node).display")
+            == "none"
+        )
+
+    page.keyboard.press("p")
+    assert player.get_attribute("data-state") == "paused"
+    page.keyboard.press("p")
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    page.keyboard.press("r")
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+    page.keyboard.press("?")
+    assert page.locator("[data-ms-help]").is_visible()
+    page.keyboard.press("Escape")
+    assert not page.locator("[data-ms-help]").is_visible()
+    assert player.get_attribute("data-presenting") == "true"
+    page.keyboard.press("o")
+    assert page.locator("[data-ms-overview]").is_visible()
+    page.keyboard.press("Escape")
+    assert not page.locator("[data-ms-overview]").is_visible()
+    assert player.get_attribute("data-presenting") == "true"
+
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]').dataset.presenting === 'false'"
+    )
+    assert (
+        page.locator(".ms-controls").evaluate("node => getComputedStyle(node).display")
+        != "none"
+    )
+    assert all(not url.startswith(("http://", "https://")) for url in requests)
+    context.close()
+
+
+def test_present_fullscreen_exit_synchronizes_and_f_toggles_mode(
+    browser, tmp_path: Path, motion_config: PresentationConfig
+) -> None:
+    output = tmp_path / "present-fullscreen.html"
+    HtmlPlayer(presentation_configs=[motion_config], one_file=True).convert_to(output)
+    context, page, _requests = open_portable(browser, output)
+    wait_playing_and_assert_time_advances(page, "playing-forward")
+
+    page.get_by_role("button", name="Enter presentation mode").click()
+    page.wait_for_function(
+        "document.fullscreenElement === document.querySelector('[data-ms-player]')"
+    )
+    page.evaluate("document.exitFullscreen()")
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]').dataset.presenting === 'false'"
+    )
+
+    page.locator("[data-ms-player]").focus()
+    page.keyboard.press("f")
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]').dataset.presenting === 'true'"
+    )
+    page.keyboard.press("f")
+    page.wait_for_function(
+        "document.querySelector('[data-ms-player]').dataset.presenting === 'false'"
+    )
     context.close()
 
 
@@ -396,79 +539,18 @@ def test_mobile_swipe_resize_and_autoplay_recovery(
     )
     assert page.locator("[data-ms-gesture]").is_visible()
     page.locator("[data-ms-gesture]").click()
-    wait_held(page, 0)
+    wait_playing_and_assert_time_advances(page, "playing-forward")
 
-    stage = page.locator("[data-ms-stage]")
-    stage.dispatch_event(
-        "pointerdown",
-        {
-            "pointerId": 1,
-            "pointerType": "touch",
-            "isPrimary": True,
-            "button": 0,
-            "clientX": 330,
-            "clientY": 400,
-        },
-    )
-    stage.dispatch_event(
-        "pointermove",
-        {
-            "pointerId": 1,
-            "pointerType": "touch",
-            "isPrimary": True,
-            "clientX": 80,
-            "clientY": 400,
-        },
-    )
-    stage.dispatch_event(
-        "pointerup",
-        {
-            "pointerId": 1,
-            "pointerType": "touch",
-            "isPrimary": True,
-            "button": 0,
-            "clientX": 80,
-            "clientY": 400,
-        },
-    )
+    swipe(page, pointer_id=1, start=(330, 400), end=(80, 400))
+    wait_held(page, 0)
+    swipe(page, pointer_id=2, start=(330, 400), end=(80, 400))
     wait_held(page, 1)
     page.set_viewport_size({"width": 844, "height": 390})
     assert page.locator("[data-ms-player]").bounding_box()["width"] == pytest.approx(
         844, abs=1
     )
 
-    stage.dispatch_event(
-        "pointerdown",
-        {
-            "pointerId": 2,
-            "pointerType": "touch",
-            "isPrimary": True,
-            "button": 0,
-            "clientX": 400,
-            "clientY": 80,
-        },
-    )
-    stage.dispatch_event(
-        "pointermove",
-        {
-            "pointerId": 2,
-            "pointerType": "touch",
-            "isPrimary": True,
-            "clientX": 400,
-            "clientY": 300,
-        },
-    )
-    stage.dispatch_event(
-        "pointerup",
-        {
-            "pointerId": 2,
-            "pointerType": "touch",
-            "isPrimary": True,
-            "button": 0,
-            "clientX": 400,
-            "clientY": 300,
-        },
-    )
+    swipe(page, pointer_id=3, start=(400, 80), end=(400, 300))
     wait_held(page, 0)
     context.close()
 
@@ -485,11 +567,6 @@ def test_loop_auto_next_pause_replay_and_error_state(
         presentation_configs=[PresentationConfig(slides=slides, resolution=(160, 90))]
     ).convert_to(output)
     context, page, _requests = open_portable(browser, output)
-    page.wait_for_function(
-        "document.querySelector('[data-ms-player]').dataset.state === 'paused'",
-        timeout=10_000,
-    )
-    page.locator("[data-ms-gesture]").click()
     page.wait_for_function(
         "document.querySelector('[data-ms-player]').dataset.slideIndex === '1'",
         timeout=10_000,

--- a/tests/test_html_player_core.py
+++ b/tests/test_html_player_core.py
@@ -1,5 +1,5 @@
 import shutil
-import subprocess
+import subprocess  # nosec B404
 from pathlib import Path
 
 import pytest
@@ -7,8 +7,10 @@ import pytest
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
 def test_player_core_state_machine(project_folder: Path) -> None:
-    result = subprocess.run(
-        ["node", "--test", "tests/player_core.test.cjs"],
+    node = shutil.which("node")
+    assert node is not None
+    result = subprocess.run(  # nosec B603
+        [node, "--test", "tests/player_core.test.cjs"],
         cwd=project_folder,
         check=False,
         capture_output=True,

--- a/tests/test_html_player_core.py
+++ b/tests/test_html_player_core.py
@@ -1,0 +1,17 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_player_core_state_machine(project_folder: Path) -> None:
+    result = subprocess.run(
+        ["node", "--test", "tests/player_core.test.cjs"],
+        cwd=project_folder,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -2006,14 +2006,10 @@ sphinx-directive = [
 
 [package.dev-dependencies]
 browser-tests = [
-    { name = "manim-slides", extra = ["full", "manim", "manimgl", "sphinx-directive"] },
     { name = "playwright" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-env" },
-    { name = "pytest-missing-modules" },
-    { name = "pytest-qt" },
-    { name = "setuptools" },
 ]
 dev = [
     { name = "bump-my-version" },
@@ -2134,14 +2130,10 @@ provides-extras = ["full", "magic", "manim", "manimgl", "pyqt6", "pyqt6-full", "
 
 [package.metadata.requires-dev]
 browser-tests = [
-    { name = "manim-slides", extras = ["full", "manim", "manimgl", "sphinx-directive"] },
     { name = "playwright", specifier = "==1.62.0" },
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-env", specifier = ">=0.8.2" },
-    { name = "pytest-missing-modules", specifier = ">=0.1.0" },
-    { name = "pytest-qt", specifier = ">=4.2.0" },
-    { name = "setuptools", specifier = ">=73.0.1" },
 ]
 dev = [
     { name = "bump-my-version", specifier = ">=0.20.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -1196,6 +1196,92 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/67/07ecd6d85c0f253363cbc4ac9e7dd048ca571a267fbccfea084d6009ac3b/greenlet-3.5.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:816230f469381ad0a43abc9fa8dda5a699e32fb78958dde32ded93213b70a667", size = 292971, upload-time = "2026-08-10T13:28:09.837Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/426733bc24247ee17bb76df90f550c299ff5f8572b2bdd7cacb5c53fd994/greenlet-3.5.5-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5433cf291e0ef9114bd14d0d824db6e5e4a43033234bca48181a9597acca07b", size = 609290, upload-time = "2026-08-10T14:14:32.273Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/dc/17d3a5acceb2fd0bbc9682a228117b719cdfb68085e6dbb33fa325755f27/greenlet-3.5.5-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:19d59f068887d8c5907fc177f27683413ace3011b6ed646c0b309266e74a6502", size = 622650, upload-time = "2026-08-10T14:27:22.004Z" },
+    { url = "https://files.pythonhosted.org/packages/74/3f/b31e6bd6adb8f80492efb6a47e8f9cd0e7335db5aac2795b1876d5afcfee/greenlet-3.5.5-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:86c5113d698cb8d927b2750bb1f1d59eefe3a37e0e0217491aee29a7f84ef52c", size = 629560, upload-time = "2026-08-10T14:30:04.733Z" },
+    { url = "https://files.pythonhosted.org/packages/51/91/00b3c0566316c6f383ea16ee05388ec4f57f6e0afa49e72ae471eda8c47f/greenlet-3.5.5-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ff00e12102358292087274dfb1669132387ff6e7920ebf9d85f4826ce0d3a56", size = 622819, upload-time = "2026-08-10T13:40:46.562Z" },
+    { url = "https://files.pythonhosted.org/packages/18/5e/58c561efde575c4ca070030e2e0513e8d1b07b76d8a2d84a9bcef1becd42/greenlet-3.5.5-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:c69bed34470abfcd456984fdadaa18e62169af4480335c45f3c32d1d9c12e638", size = 425489, upload-time = "2026-08-10T14:29:59.768Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/78/52de4f7ac9152ad1dbc8f437895c1e573d30ee1e1427e0f91a280e2417b6/greenlet-3.5.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:523bb8e27614d77101ea7a8cf59f8d91219b72d5c29f6a038c92b50828bfa8d0", size = 1582164, upload-time = "2026-08-10T14:15:02.645Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ff/c3855a00c2417e8f61c7b9f0bc4f8f599c6928f5c15681ad251e78a91e05/greenlet-3.5.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f1e2db190db51c17433eee424803818cf0670bf049d9cfe0dd07be111d1aa7c4", size = 1648807, upload-time = "2026-08-10T13:40:27.471Z" },
+    { url = "https://files.pythonhosted.org/packages/70/21/d29ff6a79dbd1ec1fe74c155d25d4c5a85e221d6b9ffc2cc7a709e7c8c39/greenlet-3.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:740e544169527b82695ce76af2f7ad6f030904658f2f3921a1d245771fb88cfc", size = 322832, upload-time = "2026-08-10T13:28:10.85Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a3/07297917485ee2ca85bc3c8dc6ed85ad3fffcf424047fba62671dba68e97/greenlet-3.5.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:be63afcbbccfad3dd95a1ba12ada84dab2ef32031973d80b5b92df67fa763a61", size = 294165, upload-time = "2026-08-10T13:25:17.987Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/6f732f9314cda54c5fd48a7620c7160f4f286967e8045ad94b9d66ce80b7/greenlet-3.5.5-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a268024ce2d7d2b04694bf1594058981a9fa663d1df4b762dee499211ed7c1c", size = 613610, upload-time = "2026-08-10T14:14:33.829Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c0/b27589e25d220289edcd4d582b2b17b83058d1a56d53d971b6ea1a34f10d/greenlet-3.5.5-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35cbb8bf55ace57fbccb4fb8622c4521713acd8691e77f4696d416ea7ca527da", size = 625481, upload-time = "2026-08-10T14:27:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/39/82/5c873dbb4fb001d22fbbd50e80d4c1b0181ddae106856132160f84b94e88/greenlet-3.5.5-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:abc8bc8d9f935cd685457545b6a53863a877fdc12c2c0f5ee9beee18d9db139c", size = 633329, upload-time = "2026-08-10T14:30:06.062Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2d/f2c928218ac52f26d7a2c188c171d1b7e728b23782cb3347e7b4fce1493a/greenlet-3.5.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cc6df89ec5302337adc9cf096221cbed2510fd444b0e0f1586cf0470740864", size = 624562, upload-time = "2026-08-10T13:40:48.064Z" },
+    { url = "https://files.pythonhosted.org/packages/70/12/f7df98e72a8eb4a7edfec5a08d6d1a4ab53a52c95ba0b2ea6c10b8dd9bd0/greenlet-3.5.5-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:3134291427bb0f3526e9d90311988caf336eb43730e95244997a4fb15f45144f", size = 428145, upload-time = "2026-08-10T14:30:01.071Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4a/92fc51d5d35912f4f06eec037ba347985defd0be47463a010a325634d9d2/greenlet-3.5.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d9b454c5fc48aeaa7c4337813dbf513a6870468e426438a04d922c6d0fe63db", size = 1584909, upload-time = "2026-08-10T14:15:04.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/58/ed98b80ac5738c149a5258544843c45601ade1fd70f61740cdaead6351b3/greenlet-3.5.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03551ed792cb1b4fc0277a0c60dfd8c343894a0ba06fe60dcd22f568b433da39", size = 1651184, upload-time = "2026-08-10T13:40:28.879Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/be/b582ceb80cefdf9d8da34078714e4b12b3d16f509dee0f65e40a5cc8fc7d/greenlet-3.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:ab3df3dffb58bf70564e93a5cec7941e4d9faa5a36cc4234a10d3131afe04f53", size = 323280, upload-time = "2026-08-10T13:26:07.495Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/18/5313c4c58598c38b0373c013e4ff2b3e6d258aaaa338f373335ebecdaddd/greenlet-3.5.5-cp311-cp311-win_arm64.whl", hash = "sha256:2b70a766135540c472ac1393d57c2e1b4a2eb85bf526a1e41e6d096173a8cee5", size = 307785, upload-time = "2026-08-10T13:28:34.874Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/7e/9ecd0285e3153532ae07aeb88063c43c72b4221cf0d4d123b02f3682e3ff/greenlet-3.5.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:49520f0c95a48b42cf55414b8e8479beb274ea70431afc33e3f79903c71f4380", size = 295809, upload-time = "2026-08-10T13:25:34.023Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/60e4bbcc89252037b18087f2ec16405d5b2d5be42dde191bbf3667e96102/greenlet-3.5.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55272212cbc5f43d1d723725ab931f1939969b7e9523882ca58b55061769d053", size = 611910, upload-time = "2026-08-10T14:14:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/cd5134be659cd4a443e7a61ae670dabec165a814c51162916d637b6dd38e/greenlet-3.5.5-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655bca754a2ef4efcb0eb48a94d3f4593536d0f3d48f8ed44343c01d16a92f95", size = 624198, upload-time = "2026-08-10T14:27:25.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/30/87c212b5c684d0e72974f1063b7a9687631e8985902c06e1016542c874e7/greenlet-3.5.5-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ca5d6ae0739e5764f2cfcfaa562ac5a990cbdaedca93251c5e3cf07c362371f", size = 629504, upload-time = "2026-08-10T14:30:07.967Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:147b25a42e5ca5be3d42356e8f608b37af715a1c196e9bf9d1627f3341adfe1d", size = 621439, upload-time = "2026-08-10T13:40:49.391Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2c/eb487fafc9f50ffff2b1e0b697f70fb34bf150821c08ab225aacf5583a7e/greenlet-3.5.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:1b5ed9162c0c098e0bbc2cf88a94f433c1b8926f831745252e099e5d83e17759", size = 432462, upload-time = "2026-08-10T14:30:02.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8b/6acf112ed8aee499f25b4d6949820fb02ac950ff9c1f3d793bd5be0599f2/greenlet-3.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:27493374cff1d1b7919dc8126547f2aea582737e3046147b434b1e12de56389b", size = 1581342, upload-time = "2026-08-10T14:15:05.653Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/734e5f198888876b42d7616ff6644c075baf6b8a2412deadd6b0e1b8b20c/greenlet-3.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12e2ee66c2aba86133f10fd99d6a8856c6d351ffb7be0e4d52ef2cc5fbb705b2", size = 1645744, upload-time = "2026-08-10T13:40:30.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/30/1f42b88dc587b5899ee50616ad56ee40cafaf225df4fb829f10183c62a5c/greenlet-3.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:49ddacd36af37735fab103846f4ee4d18a492dde72730d1699c0c8ebe30d9f18", size = 324171, upload-time = "2026-08-10T13:28:44.472Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e5/4dee4d8d2e603fe5fdd7b444e63219f7b9bd852c60c6214511c7157cbe88/greenlet-3.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:5f1b1ff4828cdc1aba4266aff814085d04a1d07959287219af021b838b265d52", size = 308362, upload-time = "2026-08-10T13:26:46.839Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3d/8cef5f724ec0d4add2af8961d504535ec60c3cca9e464f6d03bdba29d85b/greenlet-3.5.5-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:b79fd2a5bc099b5e744f34c4c9a58954a5f4cb7529fb4b6e8446057d61b6edaa", size = 294730, upload-time = "2026-08-10T13:27:51.206Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4b/8e7aa3f514273aecff30a16ab1bac09ff54cfc7e6860fdd8058c37ff2499/greenlet-3.5.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:634cf15a233a949136879dd388e25d3296e16f3f1e217d2456797b8579ebc6ed", size = 614536, upload-time = "2026-08-10T14:14:36.589Z" },
+    { url = "https://files.pythonhosted.org/packages/85/48/4e95e9dd5a8a397dc6a6345dd7f1935113d0fca4f85e89d3976da9cd988d/greenlet-3.5.5-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:499adea519f748407fc6806d20eedabac2884fd73b9f38d81236e190ba20dfef", size = 626924, upload-time = "2026-08-10T14:27:27.048Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/84/eaa476d6bf3816828d0d70e80dcc36bf30a058233bd889e707e693f6e860/greenlet-3.5.5-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7278591501941bb2456af102bb9cd59aab48c6cfd6e2dd68fa1290bb0c49a42", size = 632726, upload-time = "2026-08-10T14:30:09.874Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5d/398a1c71fa7a277deeb376c999979de6786f08fc2d5747a0b9d6e11738dd/greenlet-3.5.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2eabb980975cba5b93a95f6f69287d05fc05ac955bfd6a320a7c083eeb52c0b0", size = 623906, upload-time = "2026-08-10T13:40:50.501Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/0cc2849ede68579291e9c59b3ab6ec1958f98681cca5b14d8fc75bf674a4/greenlet-3.5.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:4dfc7c4470354e7b09184d1a3a985761053a2fd694ddb5b5c80242afc2c8c90b", size = 434966, upload-time = "2026-08-10T14:30:03.729Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1b/745450fc5ea9e0cb17d840d248f284db3363de736d362c7d2d883e3eadba/greenlet-3.5.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:03115c2e0a371999bf8ae616aa8d653f96641d4705c457aebaa187276e9f7537", size = 1581430, upload-time = "2026-08-10T14:15:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/29/d51b296e3191bb15d3d81ec375af1909e4466c0f395d744ed475801798a9/greenlet-3.5.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4441153ffba21b90d3ca89fe3d31f5c093ae6c0bf0cfdfc98f54cde22f95b62e", size = 1645684, upload-time = "2026-08-10T13:40:32.133Z" },
+    { url = "https://files.pythonhosted.org/packages/12/63/369f1a1625e64e9e31df3963c6044056e3fdfa3fa3fdba3c54ffefa6e987/greenlet-3.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:95c5b1f4b3a193f8a0c2de4bfdcb48d119f7f1063941f1de1f2168051b3e52dd", size = 324075, upload-time = "2026-08-10T13:26:58.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/78/649cb5c09d4d81f6dd1444e75474a7206784743283a21d24171562ac4899/greenlet-3.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:1af90aa4bc129883b340cdd6957a3bc74f60528a4993bbd1f53aaebe1d9981cc", size = 308260, upload-time = "2026-08-10T13:27:50.795Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8c/080e881fa2be95ff1ddbd6994b2bab3b1a78df3b3fcab39306011764fcc7/greenlet-3.5.5-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d4a389a852e392a6366058651a20fa5ba40d979865aa81bea2ccbdc44805070d", size = 295309, upload-time = "2026-08-10T13:26:03.032Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/0ac614e6586c0e42d4cc281a5819150f4f43685744a4c5ff77139286409d/greenlet-3.5.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70b157cd319873e8b544ddc2de158f55bbd0a9b0218c8ce9332039801518e328", size = 661185, upload-time = "2026-08-10T14:14:37.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b9/6808725354be8ad305dfe5172377664fc9642d4fc043be246b3314cf4482/greenlet-3.5.5-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8bdfd1424abcf26832961e766570cae79efdb9599d709088c9cb6ef82b194926", size = 673419, upload-time = "2026-08-10T14:27:28.652Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/52/f005d579acde46c3d1cc3cab1c9f3d5708c8a3006a4120e8cf5da801afe9/greenlet-3.5.5-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d98ef6f92e67c6dbf299dbfd8facc1b0d2d9cedf91e325e73b3d0373fe4309d8", size = 677863, upload-time = "2026-08-10T14:30:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2e/40c509967da7f254680826a2fa0dd22138ec79946c70b97542d74cde8b43/greenlet-3.5.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:182de51c6b572a705f2fafaab2e783bcf7d2760940229dfe73086cbae037af3e", size = 670822, upload-time = "2026-08-10T13:40:51.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8a/a75f8a2bdcef3c358a3147cdc9db3aa83755f0a038f766ab0bedb66f512c/greenlet-3.5.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:159df1942d88e8f784cbb38d6f18bdb365cd11319cfbb3e89623de2b97892d53", size = 480554, upload-time = "2026-08-10T14:30:05.171Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/22/c3c2eee4a8fe191d6d1d183086c56133d646024e3d70bfd414829f64560b/greenlet-3.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8fec3f165dfe332e490c3247c0f6c23b0bfc45f06496ad7f00ddb00e3d35e4dc", size = 1628469, upload-time = "2026-08-10T14:15:08.11Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/87/25babd09b94cb1f03e71db815fde463f0262e40cfbd953d58a8d77311351/greenlet-3.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c6ce25fee6cabc8bf22cb8b52e642cbb821be5b9aec8094d07ff03378141b8e9", size = 1691952, upload-time = "2026-08-10T13:40:33.502Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/5cc9701117ea4dc0eb7bf1f4f9b7888a6e2e5277ddfae095805ace50f2b6/greenlet-3.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:7dffc5c859fe6059974df1e37d7923d654a83e2ae18fdd616994270e001115e1", size = 327458, upload-time = "2026-08-10T13:27:02.868Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/594fa2de7fae7629168a404a4305d7d7e31a5742c50a801b1839543cb93d/greenlet-3.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:5e2afcfc4d4305dd715809b03da5cbe437c8984f61d8917751eb5fe4aefa3e07", size = 311146, upload-time = "2026-08-10T13:27:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e0/50cd600b469e5734c72709b6b1838b6bc63f307b573c772c3132d6ecfe92/greenlet-3.5.5-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:0e5a7de979d764aea1f5b6e95cf92b5b37741b9823702041f34b126e7f690277", size = 305471, upload-time = "2026-08-10T13:26:20.568Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a3/77acd66dfc6387b5219b2080806c0cabb73c10eb1bb44b413c40a62015ba/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fef01bd457f11fc158b130ca0027a3c365693280e8e231b65bdaf57999f39f5b", size = 672470, upload-time = "2026-08-10T14:14:39.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/71/0d178142dca3ec19f46fb2212ae73d30ad53b9d548dc64804086033a7089/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5173a72310725a74afc82c164f0e52cb8ad0de62f2bb623f24f6c0cc07d80272", size = 679973, upload-time = "2026-08-10T14:27:30.072Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ac/0d7887aa4bbfc9eba075cc428244dfc96f623478454d5ec81180d0d6bd5a/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5e9ec2e7c98e895fcea0c5cc57b2606cf86ece6d0a56578f3eb225e2af4f0387", size = 681587, upload-time = "2026-08-10T14:30:13.519Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/46eb8567302eaf787abf88d09df014e14ae3baf460af1b8b0efdbd3efcd5/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44f08341873200ba8a60a8bc14ace3d91f1754f7fa7bc66157714a8cd420a476", size = 676634, upload-time = "2026-08-10T13:40:53.004Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/18/8d58ba1c429b0383e3219a3d0e0bba241d0444d8ed05b73349953c7d7c7b/greenlet-3.5.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:102817506f6090b5176c746a82603341a549b40e5c3d5b72a4c672228a918c41", size = 510175, upload-time = "2026-08-10T14:30:07.047Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e9/b88bbf5b29970cb84172dc2c32aa3e5e579ceb94c808e81c826454138850/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d246c0db9a2513cd45f019ba178ea4d4d4705bd210ee465e2c15d76a1ab13874", size = 1637320, upload-time = "2026-08-10T14:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/8c/7631ed29cc6f0392f11830076e172ce4885e70b0bc2c1bce1731176d4b4e/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72507285b5caa1d17904a3f7c322ca780823a54170a0e04ec3f37bcc60d4db71", size = 1697412, upload-time = "2026-08-10T13:40:34.924Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0f/f7dd935f9c4cb1be49098770587f54d8a78518e55c89bce86c4fb4109057/greenlet-3.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7805655781fb8f28a55d05fe57ed61f5f10f1892fb587673e3bb5264f28041f0", size = 331514, upload-time = "2026-08-10T13:29:20.611Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e5/681b01f8fbc1b55232822f99e8f8afeb78a55a7c76a7bf9dbdc7ccb03a6d/greenlet-3.5.5-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:c0db80fcd5b8aece93f66c64f78a786bbb6b96c5fe63ef5a5a4581ecf8bab206", size = 295975, upload-time = "2026-08-10T13:28:45.985Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f2/69b488cd9e7267bf4b0fe8cdebf25d8d6df680d21bdf41150d23e23d6652/greenlet-3.5.5-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b241c32f912ada659808d68e308c568baf577eebf757d15471472de0c18cfad", size = 666823, upload-time = "2026-08-10T14:14:40.222Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d4/d5bc2fdebbdda0c94555925ba79948b8395d75a7f6a36cc85dce5bab9f11/greenlet-3.5.5-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ef6a08349401d8eaf3cb12688ac8557de95788556b8631ef17555a4a173022c0", size = 677613, upload-time = "2026-08-10T14:27:31.543Z" },
+    { url = "https://files.pythonhosted.org/packages/65/53/4e13642efc4d7ad6554ecb2242a5be42666b2e1a067323e88dfc0124a04b/greenlet-3.5.5-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37faa97daccb6d9f4c2141ce3118d023c3c5506864a7d8bdf726f665018c1f76", size = 681436, upload-time = "2026-08-10T14:30:14.839Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/93/542d8a3a90f3b35c6ad8bf7e56a03010287f2cafa289a5b7985b5207db39/greenlet-3.5.5-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2e3d061b8e13aec2f0441689b3c71b244a20e5d274a52cb0f7e31bd1d139552", size = 675930, upload-time = "2026-08-10T13:40:54.205Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/32/188447c9a468d6977d2989397226b0c6b65ab6f4cf943f931643328512fc/greenlet-3.5.5-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:b18007dc2473a7942fd157366b55f01da6fed7ce85318591005b419e0a439474", size = 487404, upload-time = "2026-08-10T14:30:08.903Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/89c9f2e8460d71101037d47a1feed11928615a5edd42370be290e0657eeb/greenlet-3.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:9ab5f5b93655e77fe0d6c2dfd22b5eac751bb1f876d8ec21761b7c1fb9266007", size = 1633878, upload-time = "2026-08-10T14:15:10.693Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/60/297de93f3b02ac78a5e04d32bb8bbe3080f4a73d8ed95016561463b70618/greenlet-3.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f0e5a21bd4452a88cf032fc43c4a5b307ab1380eacb63b5988f9c0317885e773", size = 1696597, upload-time = "2026-08-10T13:40:36.252Z" },
+    { url = "https://files.pythonhosted.org/packages/18/25/54c6eaff4f337fb670215e89eb2d00d9499487b658e709d4b477be4a342e/greenlet-3.5.5-cp315-cp315-win_amd64.whl", hash = "sha256:469dbb0a78625642f4a626cfd0c6e8bccc0385b5e49189b6308bbe849ec88a8e", size = 327700, upload-time = "2026-08-10T13:28:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/67/67/857e88a36301caa0e029870132c2478bd55d896630321432afab03a3115f/greenlet-3.5.5-cp315-cp315-win_arm64.whl", hash = "sha256:2d57406c3efd32d7a81e17a674314e8bd00792cdab49ea3228a49aa1bfb2e769", size = 311750, upload-time = "2026-08-10T13:34:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e2/3144c0a116067ac1e30457b0139a94d60d1d36a86e015de68e9ac87cb3bc/greenlet-3.5.5-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:68184dfcf50ccaa8e864770fe0633a7e27250ea9329f8192ef47ee9ecfd78e1c", size = 306387, upload-time = "2026-08-10T13:27:00.897Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a1/cb4223a7e9b9f43b8807e8eb212358bfe2dfaa174a9ea2889eb1714dcba2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec0dc0e59dc9c61af5c47348365ccbbd7addfafe0a93b00336ff3da2907bdc6", size = 676472, upload-time = "2026-08-10T14:14:41.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cd/a154b4498e5d8f12ada291cfb3b8d596eadde2177f5bf09a9be699d2a446/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e604f58e35833fc46ef20302bcb314dddbfd3fcf33a4f936216d51dd678d63ae", size = 684238, upload-time = "2026-08-10T14:27:32.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f4/e450a68a152f819491d8c7df6a8254e761d87e6a78759268961f8c5bd4dd/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2888a3a38bc5ee5bb6c438372197152e815837e4fab7ed7a1f86ef18ffd58ad1", size = 686022, upload-time = "2026-08-10T14:30:15.96Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/bb/b0031d260c2968a3c87deebc51d80c64e499377f993aafe06ee3b7488cc2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40239b5384f96da3963585cc6d7eaa9b56f8ae67e8d92cc82dd9e202fc847de3", size = 681246, upload-time = "2026-08-10T13:40:55.402Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/17e63d6bf3b9c9b9dbea981b7f643a71f79603bdfb4f1c3a9cf353e22aed/greenlet-3.5.5-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:1e8d9391fe77f15649589a907cef972dbbd6352ef7ff7dc0492f658c0c26495f", size = 516951, upload-time = "2026-08-10T14:30:10.907Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/07/da554b71ab88e649da146e1065d86a48a5c5d92e50ab74ef41b504aa7f56/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:a1eaccf5c3a1d3e46dead602c72e6836731e8e245c9de6a27764567b6b62d4c0", size = 1642735, upload-time = "2026-08-10T14:15:11.92Z" },
+    { url = "https://files.pythonhosted.org/packages/78/76/26a3782a051677668af9d92beaa47cd87ba9dd5072f762961144a03dd4c6/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:19e4e026fe20691f333b8eb1a3bc9625eceba8c3f9d62ec5a6f8581afbc6b5a5", size = 1700925, upload-time = "2026-08-10T13:40:37.656Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/fe7baf4190c2ae71f267efb9de21b3172bb35bc0ed1ef53dd6027d658e33/greenlet-3.5.5-cp315-cp315t-win_amd64.whl", hash = "sha256:712aee154f648bde84634654bb38bb78c69ac640c37a45c9effed800735049d8", size = 331829, upload-time = "2026-08-10T13:26:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/df/af/419a4e383bd600858a9b67e9b280a60fdc383ee3f2fe5b6c0c1ef04e74d1/greenlet-3.5.5-cp315-cp315t-win_arm64.whl", hash = "sha256:7f049911ee81a16a03c33d5450d8d5867d27f596ca5fb201b86f4524e874468b", size = 315093, upload-time = "2026-08-10T13:29:34.949Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1919,6 +2005,16 @@ sphinx-directive = [
 ]
 
 [package.dev-dependencies]
+browser-tests = [
+    { name = "manim-slides", extra = ["full", "manim", "manimgl", "sphinx-directive"] },
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-env" },
+    { name = "pytest-missing-modules" },
+    { name = "pytest-qt" },
+    { name = "setuptools" },
+]
 dev = [
     { name = "bump-my-version" },
     { name = "furo" },
@@ -2037,6 +2133,16 @@ requires-dist = [
 provides-extras = ["full", "magic", "manim", "manimgl", "pyqt6", "pyqt6-full", "pyside6", "pyside6-full", "sphinx-directive"]
 
 [package.metadata.requires-dev]
+browser-tests = [
+    { name = "manim-slides", extras = ["full", "manim", "manimgl", "sphinx-directive"] },
+    { name = "playwright", specifier = "==1.62.0" },
+    { name = "pytest", specifier = ">=7.4.0" },
+    { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "pytest-env", specifier = ">=0.8.2" },
+    { name = "pytest-missing-modules", specifier = ">=0.1.0" },
+    { name = "pytest-qt", specifier = ">=4.2.0" },
+    { name = "setuptools", specifier = ">=73.0.1" },
+]
 dev = [
     { name = "bump-my-version", specifier = ">=0.20.3" },
     { name = "furo", specifier = ">=2023.5.20" },
@@ -3165,6 +3271,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3471,6 +3596,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326, upload-time = "2021-03-10T02:09:54.659Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327, upload-time = "2021-03-10T02:09:53.503Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


## Description

This PR adds an opt-in, first-party HTML presentation exporter:

```bash
manim-slides convert SCENE presentation.html --to=html-player
```

The new exporter packages rendered Manim Slides media with a dependency-free browser player. Adding `--one-file` produces a genuinely self-contained HTML file that can be opened directly through `file://` without a server, CDN, or network connection.

## Portable demo
[Download the portable `ConvertExample` presentation](https://github.com/user-attachments/files/31603013/ManimSlides_ConvertExample_portable.html)

Generated from the repository’s existing `ConvertExample` scene without source modifications:

```console
manim-slides convert ConvertExample presentation.html --to=html-player --one-file
```

The attachment contains 13 slides with forward/reverse animations, loops, and auto-advance in one 4.1 MB file. Download it and open it directly in a modern browser; it requires no server, network connection, or adjacent assets.

### Highlights

- Adds `html-player` as an explicit conversion target while keeping the existing RevealJS exporter and `.html` auto-detection behavior unchanged.
- Supports both asset-backed output and portable `--one-file` output with lazy Blob-backed media.
- Preserves generated forward and reverse media as first-class assets.
- Supports replay, pause/resume, looping, `auto_next`, notes, multiple scenes, vertical navigation, keyboard, pointer, and mobile swipe input.
- Uses presentation-style forward input: the first forward action finishes the current animation, and the next advances.
- Respects `prefers-reduced-motion`; one explicit Play, Replay, or Present action enables animation for that player session.
- Adds a clean Present mode that hides viewer chrome and requests browser fullscreen while remaining useful if fullscreen is unavailable or rejected.
- Produces actionable slide- and asset-specific loading errors.
- Introduces no runtime framework, CDN, telemetry, or network dependency.

The player runtime is separated into a deterministic state-machine core, browser/media effects, conversion and packaging, styling, and a versioned serialized manifest.

### Verification

- `node --test tests/player_core.test.cjs`: 10 passed
- `uv run pytest -q`: 244 passed, 9 skipped
- Real Chromium browser suite with `MANIM_SLIDES_BROWSER_TESTS=1`: 8 passed
- Changed-file formatting and lint hooks: passed
- Pinned `ty` check over the tracked project sources: passed
- `git diff --check`: passed

The Chromium tests exercise top-level `file://` playback, Blob media, blocked HTTP/HTTPS requests, forward and reverse navigation, replay, rapid input, reduced-motion consent, mobile touch input, Present mode, fullscreen rejection, and fullscreen-exit synchronization.

## Check List

Check all the applicable boxes:

- [x] I understand that my contributions needs to pass the checks;
- [x] If I created new functions / methods, I documented them and add type hints;
- [x] If I modified already existing code, I updated the documentation accordingly;
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

No screenshot is attached. The generated player's interaction behavior is covered by the real-browser tests described above. I can add a short recording if that would help review the presentation flow.

## Note to reviewers

This contribution is intentionally additive. It does not alter Manim rendering, slide generation, the desktop player, or the existing RevealJS exporter.

`F` is the single command for entering or leaving Present mode so the player does not maintain conflicting fullscreen states. F5 is deliberately not bound because browsers reserve it for reload.

On Windows, the full Sphinx build successfully parsed and rendered the changed HTML-player reference page, then encountered an unrelated existing failure in the `magic_example` notebook extension (`_log_rendering_times: list index out of range`).

Development disclosure: I used an AI-assisted development tool for repository analysis, implementation, and test iteration. I reviewed the resulting changes and verification evidence and remain responsible for the contribution.
